### PR TITLE
Feature/diagnostics

### DIFF
--- a/firmware/include/cli.h
+++ b/firmware/include/cli.h
@@ -41,6 +41,7 @@ private:
     void printHeader(const __FlashStringHelper *title, uint8_t background = 255, uint8_t foreground = 255);
     void printFooter(bool failure = false);
     void printSeparator(char character = '-');
+    void printMenuFooter();
     void printCenteredText(const __FlashStringHelper *text);
     void clearArea(uint8_t start_row, uint8_t end_row);
     void logMessage(const __FlashStringHelper *message, LogType severity = LogType::INFO);
@@ -70,7 +71,7 @@ public:
     // Metodi di disegno delle schermate
     void drawRealTimeSignals(bool full_update = true);
     bool drawHardwareFailure(bool mcp_init, bool mcp_normal, bool supply_init, bool return_init);
-    void drawDiagnosticsScreen(bool full_update = true);
+    void drawDiagnosticsScreen(bool full_update = true, char input = 0);
     void drawSystemInfoScreen(bool full_update = true);
     void drawCalibrationScreen(bool full_update = true, char input = 0);
     void drawLogScreen(bool full_update = true);

--- a/firmware/include/config.h
+++ b/firmware/include/config.h
@@ -31,3 +31,7 @@
 #define PT100_FILTER_RC 5000  // 5s
 #define PT100_SAMPLE_RATE 100 // 100ms
 #define PT100_ALPHA ((float)PT100_SAMPLE_RATE / ((float)PT100_FILTER_RC + PT100_SAMPLE_RATE))
+
+// EEPROM layout
+// First byte reserved for diagnostics storage start (logical offset)
+#define DIAGNOSTICS_EEPROM_OFFSET 0x40

--- a/firmware/include/dtc.h
+++ b/firmware/include/dtc.h
@@ -4,11 +4,12 @@
 
 #pragma once
 
-#define MAGIC_NUMBER 0x1234
+#define MAGIC_NUMBER 0x5886
 
 typedef enum
 {
-    DTC_SupplyLineRtdHighThres = 0,
+    DTC_DSMEepromFailure = 0,
+    DTC_SupplyLineRtdHighThres,
     DTC_SupplyLineRtdLowThres,
     DTC_SupplyLineRefInHigh,
     DTC_SupplyLineRefInLow,
@@ -25,6 +26,7 @@ typedef enum
     DTC_CANBusOff,
     DTC_CANBusErrorPassive,
     DTC_CANBusDeviceError,
+
 } dtc_enum_t;
 
 typedef enum

--- a/firmware/include/dtc.h
+++ b/firmware/include/dtc.h
@@ -1,0 +1,197 @@
+#include "dtc_dict.h"
+#include <avr/pgmspace.h>
+#include <string.h>
+
+#pragma once
+
+#define MAGIC_NUMBER 0x1234
+
+typedef enum
+{
+    DTC_SupplyLineRtdHighThres = 0,
+    DTC_SupplyLineRtdLowThres,
+    DTC_SupplyLineRefInHigh,
+    DTC_SupplyLineRefInLow,
+    DTC_SupplyLineRtdInLow,
+    DTC_SupplyLineUOV,
+    DTC_SupplyLineDeviceError,
+    DTC_ReturnLineRtdHighThres,
+    DTC_ReturnLineRtdLowThres,
+    DTC_ReturnLineRefInHigh,
+    DTC_ReturnLineRefInLow,
+    DTC_ReturnLineRtdInLow,
+    DTC_ReturnLineUOV,
+    DTC_ReturnLineDeviceError,
+    DTC_CANBusOff,
+    DTC_CANBusErrorPassive,
+    DTC_CANBusDeviceError,
+} dtc_enum_t;
+
+typedef enum
+{
+    OFF = 0,
+    ONE_BLINK = 1,
+    TWO_BLINKS = 2,
+    THREE_BLINKS = 3,
+    SOLID = 4,
+    FLASHING = 5,
+    FLICKERING = 6,
+} red_lamp_state_t;
+
+const char DTC_DSMEepromFailure_[] PROGMEM = "DTC_DSMEepromFailure";
+const char DTC_SupplyLineRtdHighThres_[] PROGMEM = "DTC_SupplyLineRtdHighThres";
+const char DTC_SupplyLineRtdLowThres_[] PROGMEM = "DTC_SupplyLineRtdLowThres";
+const char DTC_SupplyLineRefInHigh_[] PROGMEM = "DTC_SupplyLineRefInHigh";
+const char DTC_SupplyLineRefInLow_[] PROGMEM = "DTC_SupplyLineRefInLow";
+const char DTC_SupplyLineRtdInLow_[] PROGMEM = "DTC_SupplyLineRtdInLow";
+const char DTC_SupplyLineUOV_[] PROGMEM = "DTC_SupplyLineUOV";
+const char DTC_SupplyLineDeviceError_[] PROGMEM = "DTC_SupplyLineDeviceError";
+const char DTC_ReturnLineRtdHighThres_[] PROGMEM = "DTC_ReturnLineRtdHighThres";
+const char DTC_ReturnLineRtdLowThres_[] PROGMEM = "DTC_ReturnLineRtdLowThres";
+const char DTC_ReturnLineRefInHigh_[] PROGMEM = "DTC_ReturnLineRefInHigh";
+const char DTC_ReturnLineRefInLow_[] PROGMEM = "DTC_ReturnLineRefInLow";
+const char DTC_ReturnLineRtdInLow_[] PROGMEM = "DTC_ReturnLineRtdInLow";
+const char DTC_ReturnLineUOV_[] PROGMEM = "DTC_ReturnLineUOV";
+const char DTC_ReturnLineDeviceError_[] PROGMEM = "DTC_ReturnLineDeviceError";
+const char DTC_CANBusOff_[] PROGMEM = "DTC_CANBusErrorBusOff";
+const char DTC_CANBusErrorPassive_[] PROGMEM = "DTC_CANBusErrorPassive";
+const char DTC_CANBusDeviceError_[] PROGMEM = "DTC_CANBusDeviceError";
+// // Add more strings as needed
+
+const dtc_entity_t dtc_dict_entries[] PROGMEM = {
+    {523700, 0, DTC_DSMEepromFailure_, 0, red_lamp_state_t::THREE_BLINKS}, // DTC_DSMEepromFailure (diagnostics EEPROM failure)
+
+    {441, 0, DTC_SupplyLineRtdHighThres_, 5, red_lamp_state_t::FLASHING},   // DTC_SupplyLineRtdHighThres
+    {441, 1, DTC_SupplyLineRtdLowThres_, 5, red_lamp_state_t::FLASHING},    // DTC_SupplyLineRtdLowThres
+    {441, 3, DTC_SupplyLineRefInHigh_, 5, red_lamp_state_t::FLASHING},      // DTC_SupplyLineRefInHigh
+    {441, 4, DTC_SupplyLineRefInLow_, 5, red_lamp_state_t::FLASHING},       // DTC_SupplyLineRefInLow
+    {441, 15, DTC_SupplyLineRtdInLow_, 5, red_lamp_state_t::FLASHING},      // DTC_SupplyLineRtdInLow
+    {441, 5, DTC_SupplyLineUOV_, 5, red_lamp_state_t::FLASHING},            // DTC_SupplyLineUOV
+    {441, 23, DTC_SupplyLineDeviceError_, 0, red_lamp_state_t::FLICKERING}, // DTC_SupplyLineDeviceError
+
+    {442, 0, DTC_ReturnLineRtdHighThres_, 5, red_lamp_state_t::FLASHING},   // DTC_ReturnLineRtdHighThres
+    {442, 1, DTC_ReturnLineRtdLowThres_, 5, red_lamp_state_t::FLASHING},    // DTC_ReturnLineRtdLowThres
+    {442, 3, DTC_ReturnLineRefInHigh_, 5, red_lamp_state_t::FLASHING},      // DTC_ReturnLineRefInHigh
+    {442, 4, DTC_ReturnLineRefInLow_, 5, red_lamp_state_t::FLASHING},       // DTC_ReturnLineRefInLow
+    {442, 15, DTC_ReturnLineRtdInLow_, 5, red_lamp_state_t::FLASHING},      // DTC_ReturnLineRtdInLow
+    {442, 5, DTC_ReturnLineUOV_, 5, red_lamp_state_t::FLASHING},            // DTC_ReturnLineUOV
+    {442, 23, DTC_ReturnLineDeviceError_, 0, red_lamp_state_t::FLICKERING}, // DTC_ReturnLineDeviceError
+
+    {639, 12, DTC_CANBusOff_, 5, red_lamp_state_t::THREE_BLINKS},         // DTC_CANBusOff
+    {639, 2, DTC_CANBusErrorPassive_, 5, red_lamp_state_t::THREE_BLINKS}, // DTC_CANBusErrorPassive
+    {639, 23, DTC_CANBusDeviceError_, 0, red_lamp_state_t::FLICKERING},   // DTC_CANBusDeviceError
+
+    // Add more DTC definitions as needed
+};
+
+/**
+ * @brief Concrete implementation of DTC_Dict for TFM-100 firmware
+ * @remarks Uses the dtc_dict_entries[] PROGMEM array defined in dtc.h
+ */
+class TFM100_DTC_Dict : public DTC_List
+{
+public:
+    /**
+     * @brief Constructor using the global DTC entries table
+     */
+    TFM100_DTC_Dict()
+    {
+        tbl_ = dtc_dict_entries;
+        numberOfErrors_ = sizeof(dtc_dict_entries) / sizeof(dtc_entity_t);
+    }
+
+    /**
+     * @brief Get SPN (Suspect Parameter Number) for a DTC entry
+     * @param idx Index of the DTC entry
+     * @param out_spn Output SPN value
+     * @return true if index is valid and SPN retrieved successfully
+     */
+    bool getSPN(uint16_t idx, uint32_t &out_spn) const override
+    {
+        if (!idxOK(idx))
+            return false;
+        out_spn = pgm_read_dword(&tbl_[idx].spn);
+        return true;
+    }
+
+    /**
+     * @brief Get FMI (Failure Mode Identifier) for a DTC entry
+     * @param idx Index of the DTC entry
+     * @param out_fmi Output FMI value (masked to 5 bits)
+     * @return true if index is valid and FMI retrieved successfully
+     */
+    bool getFMI(uint16_t idx, uint8_t &out_fmi) const override
+    {
+        if (!idxOK(idx))
+            return false;
+        out_fmi = pgm_read_byte(&tbl_[idx].fmi) & 0x1F;
+        return true;
+    }
+
+    /**
+     * @brief Get severity level for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Severity level, or 0xFF if index is invalid
+     */
+    uint8_t getSeverity(uint16_t idx) const override
+    {
+        if (!idxOK(idx))
+            return 0xFF; // Invalid severity
+        return pgm_read_byte(&tbl_[idx].severity);
+    }
+
+    /**
+     * @brief Get human-readable name for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Pointer to string in RAM (copied from PROGMEM), or nullptr if index is invalid
+     */
+    const char *getName(uint16_t idx) const override
+    {
+        if (!idxOK(idx))
+            return nullptr;
+
+        // Read the pointer from PROGMEM struct
+        const char *progmem_ptr = reinterpret_cast<const char *>(pgm_read_ptr(&tbl_[idx].name));
+
+        // Use static buffer to copy PROGMEM string to RAM
+        static char buffer[64]; // Adjust size as needed
+        strcpy_P(buffer, progmem_ptr);
+        return buffer;
+    }
+
+    /**
+     * @brief Get debounce ticks for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Debounce ticks, or 0xFF if index is invalid
+     */
+    uint8_t getDebounceTicks(uint16_t idx) const override
+    {
+        if (!idxOK(idx))
+            return 0xFF;
+        return pgm_read_byte(&tbl_[idx].debounce_ticks);
+    }
+
+    /**
+     * @brief Get total number of DTC entries
+     * @return Number of DTC entries in the dictionary
+     */
+    uint16_t getNumberOfErrors() const override
+    {
+        return numberOfErrors_;
+    }
+
+    /**
+     * @brief Get magic number for EEPROM storage
+     * @return Magic number
+     */
+    uint16_t getMagicNumber() const override
+    {
+        return MAGIC_NUMBER;
+    }
+
+private:
+    const dtc_entity_t *tbl_; ///< Pointer to PROGMEM DTC table
+    uint8_t numberOfErrors_;  ///< Number of entries in the table
+
+    inline bool idxOK(uint16_t idx) const { return idx < numberOfErrors_; }
+};

--- a/firmware/include/utils.h
+++ b/firmware/include/utils.h
@@ -1,5 +1,5 @@
 /**
- * @file mini_printf.h
+ * @file utils.h
  * @brief Very small, dependency-free helpers to format small strings without pulling full printf.
  * @author helper
  * @note Keep implementations to allow compiler to optimize and avoid extra code size.

--- a/firmware/include/utils.h
+++ b/firmware/include/utils.h
@@ -1,0 +1,113 @@
+/**
+ * @file mini_printf.h
+ * @brief Very small, dependency-free helpers to format small strings without pulling full printf.
+ * @author helper
+ * @note Keep implementations to allow compiler to optimize and avoid extra code size.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * @brief Format an unsigned long as "0x" followed by 6 uppercase hex digits into dst.
+ * @param dst Output buffer (must have space for at least 9 chars: "0x" + 6 + '\0')
+ * @param value Unsigned long value to format
+ * @return None
+ */
+static inline void mini_hex6(char *dst, unsigned long value)
+{
+    const char hex[] = "0123456789ABCDEF";
+    dst[0] = '0';
+    dst[1] = 'x';
+    for (int i = 0; i < 6; ++i)
+    {
+        unsigned int shift = (5 - i) * 4;
+        unsigned int nibble = (value >> shift) & 0x0F;
+        dst[2 + i] = hex[nibble];
+    }
+    dst[8] = '\0';
+}
+
+/**
+ * @brief Format an unsigned integer into dst, padded left to width (width <= 10).
+ * @param dst Output buffer (must have at least width+1 bytes)
+ * @param value Unsigned long value to format
+ * @param width Minimum width (padded with spaces on the left)
+ * @return None
+ * @remarks If width is small and value larger, it prints full value.
+ */
+static inline void mini_udec_padded(char *dst, unsigned long value, uint8_t width)
+{
+    char tmp[12];
+    int len = 0;
+    if (value == 0)
+    {
+        tmp[len++] = '0';
+    }
+    else
+    {
+        unsigned long v = value;
+        while (v > 0)
+        {
+            tmp[len++] = '0' + (v % 10);
+            v /= 10;
+        }
+        for (int i = 0; i < len / 2; ++i)
+        {
+            char c = tmp[i];
+            tmp[i] = tmp[len - 1 - i];
+            tmp[len - 1 - i] = c;
+        }
+    }
+    int pad = (int)width - len;
+    char *p = dst;
+    while (pad-- > 0)
+        *p++ = ' ';
+    for (int i = 0; i < len; ++i)
+        *p++ = tmp[i];
+    *p = '\0';
+}
+
+/**
+ * @brief Converts a float to string with specified decimals, minimal RAM usage.
+ * @param buf Output buffer (must be large enough)
+ * @param f Float value to convert
+ * @param decimals Number of decimal places
+ * @return None
+ * @remarks Uses integer math, no heap, buffer must be at least 12 bytes for 2 decimals.
+ */
+static inline void ftostr(char *buf, float f, uint8_t decimals)
+{
+    int32_t mult = 1;
+    for (int i = 0; i < decimals; ++i)
+        mult *= 10;
+    int32_t value = (int32_t)(f * mult + (f < 0 ? -0.5f : 0.5f));
+    int32_t int_part = value / mult;
+    int32_t frac_part = abs(value % mult);
+
+    // Print integer part
+    char *p = buf;
+    if (int_part < 0)
+    {
+        *p++ = '-';
+        int_part = -int_part;
+    }
+    itoa(int_part, p, 10);
+    while (*p)
+        ++p;
+
+    // Print decimal part
+    if (decimals > 0)
+    {
+        *p++ = '.';
+        int pow10 = mult / 10;
+        for (int i = 0; i < decimals; ++i)
+        {
+            *p++ = '0' + (frac_part / pow10) % 10;
+            pow10 /= 10;
+        }
+    }
+    *p = '\0';
+}

--- a/firmware/lib/J1939/J1939Manager.cpp
+++ b/firmware/lib/J1939/J1939Manager.cpp
@@ -235,7 +235,7 @@ void J1939Manager::processCurrent(uint16_t now_ms)
         if (sequence_counter == 0)
         {
             // Send BAM Connection Management (CM) frame to announce a large transfer
-            can_id = buildCanId(6, 0xEC00, sa_); // BAM uses PGN 0xEC00 and priority 6
+            can_id = buildCanId(6, 0xECFF, sa_); // BAM uses PGN 0xECFF (Broadcast) and priority 6
             len_frame = 8;
 
             // The source buffer (if any) was locked by startNext() prior to
@@ -267,17 +267,22 @@ void J1939Manager::processCurrent(uint16_t now_ms)
         else
         {
             // Prepare a Data Transfer (DT) frame: 1 byte sequence + up to 7 data bytes
-            can_id = buildCanId(6, 0xEB00, sa_);  // DT uses PGN 0xEB00 and priority 6
+            can_id = buildCanId(6, 0xEBFF, sa_);  // DT uses PGN 0xEBFF (Broadcast) and priority 6
             frame_payload_[0] = sequence_counter; // Sequence number (1-based)
 
             // Compute offset and how many bytes to send this DT
             uint16_t data_offset = (sequence_counter - 1) * 7;
             uint8_t bytes_to_send = min(desc.len - data_offset, 7);
-            len_frame = bytes_to_send + 1;
+            // Fill available data bytes starting at index 1
             fillFramePayload(desc, 1, data_offset, bytes_to_send);
             is_final_frame = (data_offset + bytes_to_send >= desc.len);
 
-            // Send DT
+            // Pad remaining bytes to 8-byte CAN frame with 0xFF for interoperability
+            for (uint8_t i = 1 + bytes_to_send; i < 8; i++)
+                frame_payload_[i] = 0xFF;
+            len_frame = 8;
+
+            // Send DT (always as full 8-byte frame)
             transmission_success = can_.sendExtendedFrame(can_id, frame_payload_, len_frame);
             if (transmission_success)
             {

--- a/firmware/lib/J1939/J1939_DM.cpp
+++ b/firmware/lib/J1939/J1939_DM.cpp
@@ -1,0 +1,123 @@
+#include <J1939_DM.h>
+
+bool J1939_DM1Message::shouldSend(uint16_t now_ms)
+{
+    if (now_ms - last_send_time >= send_interval_ms)
+    {
+        last_send_time = now_ms;
+        if (J1939_DM::getNumberOfActiveErrors() > 0)
+        {
+            previously_had_errors = true;
+            return true;
+        }
+        else if (previously_had_errors)
+        {
+            // We had errors previously but now none: arm the final lamp-only DM1
+            previously_had_errors = false;
+            return true;
+        }
+    }
+    return false;
+}
+
+uint8_t *J1939_DM1Message::buildPayload(uint8_t *len)
+{
+    uint8_t numberOfErrors = J1939_DM::getNumberOfActiveErrors();
+    *len = 2 + numberOfErrors * 4;
+    uint8_t *payload = new uint8_t[*len];
+    if (!payload)
+    {
+        *len = 0;
+        return nullptr;
+    }
+
+    // --- Lamp status reporting ---
+    // 00 = slow, 01 = fast, 10 = reserved, 11 = no-flash
+    constexpr uint8_t FLASH_SLOW = 0u;
+    constexpr uint8_t FLASH_FAST = 1u;
+    constexpr uint8_t FLASH_NONE = 3u; // “no flash / N.A.”
+
+    uint8_t lampStatus = 0;
+    uint8_t lampFlashing = 0;
+    J1939_DM::LampStatus lamps[4] = {
+        J1939_DM::getProtectLampStatus(),
+        J1939_DM::getWarningLampStatus(),
+        J1939_DM::getStopLampStatus(),
+        J1939_DM::getMilLampStatus(),
+    };
+
+    for (uint8_t i = 0; i < 4; i++)
+    {
+        switch (lamps[i])
+        {
+        case J1939_DM::LampStatus::OFF:
+            // Lamp Status = 00 (off), Flash = 00 (don't care)
+            break;
+        case J1939_DM::LampStatus::SOLID:
+            // Lamp Status = 01 (on), Flash = 11 (no flash)
+            lampStatus |= (1 << (2 * i));
+            lampFlashing |= (FLASH_NONE << (2 * i));
+            break;
+        case J1939_DM::LampStatus::FAST_BLINK:
+            // Lamp Status = 01 (on), Flash = 01 (fast)
+            lampStatus |= (1 << (2 * i));
+            lampFlashing |= (FLASH_FAST << (2 * i));
+            break;
+        case J1939_DM::LampStatus::SLOW_BLINK:
+            // Lamp Status = 01 (on), Flash = 00 (slow)
+            lampStatus |= (1 << (2 * i));
+            lampFlashing |= (FLASH_SLOW << (2 * i));
+            break;
+        }
+    }
+    payload[0] = lampStatus;
+    payload[1] = lampFlashing;
+
+    // --- DTCs ---
+    uint8_t *p = &payload[2];
+    for (uint8_t i = 0; i < numberOfErrors; ++i, p += 4)
+    {
+        uint32_t spn;
+        uint8_t fmi, oc;
+        J1939_DM::getErrorCode(i, spn, fmi, oc);
+        p[0] = (uint8_t)(spn & 0xFF);                // SPN[7:0]
+        p[1] = (uint8_t)((spn >> 8) & 0xFF);         // SPN[15:8]
+        p[2] = (uint8_t)((((spn >> 16) & 0x07) << 5) // SPN[18:16] nei bit 0..2
+                         | (uint8_t)(fmi & 0x1F));   // FMI nei bit 3..7
+        p[3] = (uint8_t)(oc & 0x7F);                 // Occurrence Count
+    }
+
+    return payload;
+}
+
+uint8_t __attribute__((weak)) J1939_DM::getNumberOfActiveErrors()
+{
+    return 0;
+}
+
+void __attribute__((weak)) J1939_DM::getErrorCode(uint8_t index, uint32_t &spn, uint8_t &fmi, uint8_t &oc)
+{
+    spn = 0;
+    fmi = 0;
+    oc = 0;
+}
+
+J1939_DM::LampStatus __attribute__((weak)) J1939_DM::getMilLampStatus()
+{
+    return J1939_DM::LampStatus::OFF;
+}
+
+J1939_DM::LampStatus __attribute__((weak)) J1939_DM::getStopLampStatus()
+{
+    return J1939_DM::LampStatus::OFF;
+}
+
+J1939_DM::LampStatus __attribute__((weak)) J1939_DM::getWarningLampStatus()
+{
+    return J1939_DM::LampStatus::OFF;
+}
+
+J1939_DM::LampStatus __attribute__((weak)) J1939_DM::getProtectLampStatus()
+{
+    return J1939_DM::LampStatus::OFF;
+}

--- a/firmware/lib/J1939/J1939_DM.h
+++ b/firmware/lib/J1939/J1939_DM.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <IJ1939Message.h>
+
+class J1939_DM1Message : public IJ1939Message
+{
+public:
+    J1939_DM1Message(uint16_t interval_ms) : IJ1939Message(), send_interval_ms(interval_ms) {}
+    uint32_t getPGN() override { return 0xFECA; } // PGN for DM1
+
+    bool shouldSend(uint16_t now_ms) override;
+
+    uint8_t *buildPayload(uint8_t *len) override;
+
+    bool shallPayloadCopied() override { return true; }
+
+private:
+    uint32_t last_send_time = 0;
+    uint16_t send_interval_ms;
+    bool previously_had_errors = false;
+};
+
+namespace J1939_DM
+{
+    enum LampStatus
+    {
+        OFF,
+        SOLID,
+        SLOW_BLINK,
+        FAST_BLINK,
+    };
+
+    uint8_t getNumberOfActiveErrors();
+    void getErrorCode(uint8_t index, uint32_t &spn, uint8_t &fmi, uint8_t &oc);
+    LampStatus getMilLampStatus();
+    LampStatus getStopLampStatus();
+    LampStatus getWarningLampStatus();
+    LampStatus getProtectLampStatus();
+} // namespace J1939_DM

--- a/firmware/lib/diagnostics/diagnostics.cpp
+++ b/firmware/lib/diagnostics/diagnostics.cpp
@@ -1,0 +1,193 @@
+
+#include "diagnostics.h"
+#include "dtc_dict.h"
+
+Diagnostics::Diagnostics(DTC_List *dict)
+    : dict_(dict)
+{
+    clear();
+}
+
+void Diagnostics::setRaw(uint8_t dtc_idx, bool raw)
+{
+    // Update status if exists
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) != DTC_EMPTY &&
+            errors[i].dtc_idx == dtc_idx)
+        {
+            dtc_set_raw(&errors[i], raw);
+            return;
+        }
+    }
+    // Ignore if error is not set
+    if (!raw)
+        return;
+
+    // Add new error if not exists
+    uint8_t position = UINT8_MAX;
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) == DTC_EMPTY)
+        {
+            position = i;
+            break;
+        }
+    }
+    // If no empty slot, overwrite the first History
+    if (position == UINT8_MAX)
+    {
+        for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+        {
+            if (dtc_get_state(&errors[i]) == DTC_HISTORY)
+            {
+                position = i;
+                break;
+            }
+        }
+    }
+    // If still no slot, skip adding the new error
+    if (position == UINT8_MAX)
+        return;
+    // Add new error
+    errors[position].dtc_idx = dtc_idx;
+    errors[position].occurrence = 0;
+    errors[position].flags = 0;
+    dtc_set_state(&errors[position], DTC_PENDING);
+    dtc_set_raw(&errors[position], true);
+    dtc_set_debounce(&errors[position], 0);
+    return;
+}
+
+void Diagnostics::periodic_update()
+{
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        auto &err = errors[i];
+        dtc_state_t state = dtc_get_state(&err);
+        bool raw = dtc_get_raw(&err);
+        uint8_t deb = dtc_get_debounce(&err);
+        if (deb < 15)
+            dtc_set_debounce(&err, ++deb);
+
+        switch (state)
+        {
+        case DTC_EMPTY:
+            // Nothing to do
+            break;
+        case DTC_PENDING:
+            if (raw)
+            {
+                if (deb >= dict_->getDebounceTicks(err.dtc_idx) || deb == 15)
+                {
+                    dtc_set_state(&err, DTC_ACTIVE);
+                    dtc_set_debounce(&err, 0);
+                    if (err.occurrence < 127)
+                        err.occurrence++;
+                }
+            }
+            else
+            {
+                dtc_set_debounce(&err, 0);
+                dtc_set_state(&err, DTC_HISTORY);
+            }
+            break;
+        case DTC_ACTIVE:
+            if (!raw)
+            {
+                dtc_set_debounce(&err, 1);
+                dtc_set_state(&err, DTC_HEALING);
+            }
+            break;
+        case DTC_HEALING:
+            if (!raw)
+            {
+                if (deb >= dict_->getDebounceTicks(err.dtc_idx) || deb == 15)
+                {
+                    dtc_set_state(&err, DTC_HISTORY);
+                    dtc_set_debounce(&err, 0);
+                }
+            }
+            else
+            {
+                dtc_set_debounce(&err, 0);
+                dtc_set_state(&err, DTC_ACTIVE);
+            }
+            break;
+        case DTC_HISTORY:
+            if (raw)
+            {
+                dtc_set_state(&err, DTC_PENDING);
+                dtc_set_debounce(&err, 1);
+            }
+            break;
+        }
+    }
+}
+
+void Diagnostics::clear()
+{
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        errors[i].dtc_idx = 0xFF; // Invalid index
+        errors[i].occurrence = 0;
+        errors[i].flags = 0; // Clear all flags
+        dtc_set_state(&errors[i], DTC_EMPTY);
+    }
+}
+
+uint8_t Diagnostics::numberOfActiveErrors() const
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) == DTC_ACTIVE)
+            count++;
+    }
+    return count;
+}
+
+uint8_t Diagnostics::numberOfErrors() const
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) != DTC_EMPTY)
+            count++;
+    }
+    return count;
+}
+
+const char *Diagnostics::getErrorDescription(uint8_t idx) const
+{
+    if (idx >= DIAGNOSTICS_MEMORY_SIZE)
+        return "";
+
+    const char *name = dict_->getName(errors[idx].dtc_idx);
+    if (name)
+        return name;
+    return "Unknown DTC";
+}
+
+uint8_t Diagnostics::getErrorSeverity(uint8_t idx) const
+{
+    if (idx >= DIAGNOSTICS_MEMORY_SIZE)
+        return 0xFF;
+
+    return dict_->getSeverity(errors[idx].dtc_idx);
+}
+
+uint8_t Diagnostics::getMaxSeverity() const
+{
+    uint8_t max_severity = 0;
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) != DTC_EMPTY)
+        {
+            uint8_t sev = dict_->getSeverity(errors[i].dtc_idx);
+            if (sev != 0xFF && sev > max_severity)
+                max_severity = sev;
+        }
+    }
+    return max_severity;
+}

--- a/firmware/lib/diagnostics/diagnostics.cpp
+++ b/firmware/lib/diagnostics/diagnostics.cpp
@@ -5,7 +5,13 @@
 Diagnostics::Diagnostics(DTC_List *dict)
     : dict_(dict)
 {
-    clear();
+    // Attempt to load persisted diagnostics memory (application hook).
+    // If loading fails, initialize with clear().
+    eepromLoadOk_ = loadFromEEPROM();
+    if (!eepromLoadOk_)
+    {
+        clear();
+    }
 }
 
 void Diagnostics::setRaw(uint8_t dtc_idx, bool raw)
@@ -53,9 +59,10 @@ void Diagnostics::setRaw(uint8_t dtc_idx, bool raw)
     errors[position].dtc_idx = dtc_idx;
     errors[position].occurrence = 0;
     errors[position].flags = 0;
-    dtc_set_state(&errors[position], DTC_PENDING);
     dtc_set_raw(&errors[position], true);
     dtc_set_debounce(&errors[position], 0);
+    // Use helper to set state and persist
+    setStateAndPersist(position, DTC_PENDING);
     return;
 }
 
@@ -80,23 +87,23 @@ void Diagnostics::periodic_update()
             {
                 if (deb >= dict_->getDebounceTicks(err.dtc_idx) || deb == 15)
                 {
-                    dtc_set_state(&err, DTC_ACTIVE);
-                    dtc_set_debounce(&err, 0);
                     if (err.occurrence < 127)
                         err.occurrence++;
+                    setStateAndPersist(i, DTC_ACTIVE);
+                    dtc_set_debounce(&err, 0);
                 }
             }
             else
             {
                 dtc_set_debounce(&err, 0);
-                dtc_set_state(&err, DTC_HISTORY);
+                setStateAndPersist(i, DTC_HISTORY);
             }
             break;
         case DTC_ACTIVE:
             if (!raw)
             {
                 dtc_set_debounce(&err, 1);
-                dtc_set_state(&err, DTC_HEALING);
+                setStateAndPersist(i, DTC_HEALING);
             }
             break;
         case DTC_HEALING:
@@ -104,20 +111,20 @@ void Diagnostics::periodic_update()
             {
                 if (deb >= dict_->getDebounceTicks(err.dtc_idx) || deb == 15)
                 {
-                    dtc_set_state(&err, DTC_HISTORY);
+                    setStateAndPersist(i, DTC_HISTORY);
                     dtc_set_debounce(&err, 0);
                 }
             }
             else
             {
                 dtc_set_debounce(&err, 0);
-                dtc_set_state(&err, DTC_ACTIVE);
+                setStateAndPersist(i, DTC_ACTIVE);
             }
             break;
         case DTC_HISTORY:
             if (raw)
             {
-                dtc_set_state(&err, DTC_PENDING);
+                setStateAndPersist(i, DTC_PENDING);
                 dtc_set_debounce(&err, 1);
             }
             break;
@@ -134,6 +141,8 @@ void Diagnostics::clear()
         errors[i].flags = 0; // Clear all flags
         dtc_set_state(&errors[i], DTC_EMPTY);
     }
+    // After clearing, ensure EEPROM reflects empty memory
+    saveToEEPROM();
 }
 
 /**
@@ -209,7 +218,7 @@ uint8_t Diagnostics::getMaxSeverity() const
     uint8_t max_severity = 0;
     for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
     {
-        if (dtc_get_state(&errors[i]) != DTC_EMPTY)
+        if (dtc_get_state(&errors[i]) == DTC_ACTIVE)
         {
             uint8_t sev = dict_->getSeverity(errors[i].dtc_idx);
             if (sev != 0xFF && sev > max_severity)
@@ -217,4 +226,95 @@ uint8_t Diagnostics::getMaxSeverity() const
         }
     }
     return max_severity;
+}
+
+void Diagnostics::saveEntryToEEPROM(uint8_t index)
+{
+    if (index >= DIAGNOSTICS_MEMORY_SIZE)
+        return;
+    // Ensure offset and length fit in hook parameters (uint16_t offset, uint8_t length)
+    const uint16_t offset = (uint16_t)(2 + index * sizeof(dtc_history_t));
+    const uint8_t length = (uint8_t)sizeof(dtc_history_t);
+    if (length == 0)
+        return;
+    diag_save_to_persistent(offset, reinterpret_cast<const uint8_t *>(&errors[index]), length);
+}
+
+// Helper: set state for entry index and persist only if it actually changes
+void Diagnostics::setStateAndPersist(uint8_t index, dtc_state_t newState)
+{
+    if (index >= DIAGNOSTICS_MEMORY_SIZE)
+        return;
+    dtc_state_t old = dtc_get_state(&errors[index]);
+    if (old == newState)
+        return;
+    dtc_set_state(&errors[index], newState);
+    // Persist only when entering ACTIVE or HISTORY states
+    if (newState == DTC_ACTIVE || newState == DTC_HISTORY)
+    {
+        saveEntryToEEPROM(index);
+    }
+}
+
+// Persist diagnostics memory to EEPROM if enabled
+void Diagnostics::saveToEEPROM()
+{
+    // Serialize magic and write it first, then each entry individually.
+    const uint16_t magic = dict_->getMagicNumber();
+    uint8_t buf[2];
+    buf[0] = (uint8_t)(magic & 0xFF);
+    buf[1] = (uint8_t)((magic >> 8) & 0xFF);
+    diag_save_to_persistent(0, buf, 2);
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+        saveEntryToEEPROM(i);
+}
+
+// Load diagnostics memory from EEPROM if enabled and magic matches
+bool Diagnostics::loadFromEEPROM()
+{
+    uint8_t buf[2];
+    bool ok = diag_load_from_persistent(0, buf, 2);
+    if (!ok)
+        return false;
+    // verify magic
+    uint16_t magic = (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+    if (magic != dict_->getMagicNumber())
+        return false;
+    // Load each entry individually
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        const uint16_t offset = (uint16_t)(2 + i * sizeof(dtc_history_t));
+        const uint8_t length = (uint8_t)sizeof(dtc_history_t);
+        ok = diag_load_from_persistent(offset, reinterpret_cast<uint8_t *>(&errors[i]), length);
+        if (!ok)
+            return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Default (weak) platform persistence hooks
+// Applications may override these by providing their own implementations
+// with the same signatures (without the weak attribute), e.g. in main.cpp.
+// ---------------------------------------------------------------------------
+
+// Default platform persistence hooks are no-ops here so the diagnostics
+// library remains agnostic. Applications should provide their own
+// implementations of these functions (without the weak attribute)
+// if they want persistence behavior.
+void __attribute__((weak)) diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length)
+{
+    (void)offset;
+    (void)data;
+    (void)length;
+    // no-op
+}
+
+bool __attribute__((weak)) diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length)
+{
+    (void)offset;
+    (void)data;
+    (void)length;
+    // Default: nothing loaded
+    return false;
 }

--- a/firmware/lib/diagnostics/diagnostics.cpp
+++ b/firmware/lib/diagnostics/diagnostics.cpp
@@ -136,6 +136,26 @@ void Diagnostics::clear()
     }
 }
 
+/**
+ * @brief Get the DTC index for the active error at the given position
+ * @param pos Position in the list of active errors (0-based)
+ * @return DTC index if found, or 0xFF if not found
+ */
+uint8_t Diagnostics::getIndexForActiveErrorAt(uint8_t pos) const
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+    {
+        if (dtc_get_state(&errors[i]) == DTC_ACTIVE)
+        {
+            if (count == pos)
+                return errors[i].dtc_idx;
+            count++;
+        }
+    }
+    return 0xFF; // Not found
+}
+
 uint8_t Diagnostics::numberOfActiveErrors() const
 {
     uint8_t count = 0;
@@ -167,6 +187,13 @@ const char *Diagnostics::getErrorDescription(uint8_t idx) const
     if (name)
         return name;
     return "Unknown DTC";
+}
+const uint8_t Diagnostics::getOccurrenceCount(uint8_t idx) const
+
+{
+    if (idx >= DIAGNOSTICS_MEMORY_SIZE)
+        return 0;
+    return errors[idx].occurrence;
 }
 
 uint8_t Diagnostics::getErrorSeverity(uint8_t idx) const

--- a/firmware/lib/diagnostics/diagnostics.h
+++ b/firmware/lib/diagnostics/diagnostics.h
@@ -58,8 +58,10 @@ public:
     uint8_t numberOfErrors() const;
     const dtc_history_t *getMemory() const { return errors; }
     const char *getErrorDescription(uint8_t idx) const;
+    const uint8_t getOccurrenceCount(uint8_t idx) const;
     uint8_t getErrorSeverity(uint8_t idx) const;
     uint8_t getMaxSeverity() const;
+    uint8_t getIndexForActiveErrorAt(uint8_t pos) const;
 
 private:
     DTC_List *dict_;                               // Pointer to DTC dictionary implementation

--- a/firmware/lib/diagnostics/diagnostics.h
+++ b/firmware/lib/diagnostics/diagnostics.h
@@ -51,6 +51,10 @@ public:
      */
     Diagnostics(DTC_List *dict);
 
+    // Persistence is controlled entirely by application-provided hooks.
+    // Do not provide an offset via constructor or API in the library; the
+    // application is responsible for managing any address/namespace.
+
     void setRaw(uint8_t dtc_idx, bool raw);
     void periodic_update();
     void clear();
@@ -62,8 +66,34 @@ public:
     uint8_t getErrorSeverity(uint8_t idx) const;
     uint8_t getMaxSeverity() const;
     uint8_t getIndexForActiveErrorAt(uint8_t pos) const;
+    /**
+     * @brief Returns true if the diagnostics memory was successfully loaded from persistent storage
+     */
+    bool eepromLoadOk() const { return eepromLoadOk_; }
 
 private:
-    DTC_List *dict_;                               // Pointer to DTC dictionary implementation
-    dtc_history_t errors[DIAGNOSTICS_MEMORY_SIZE]; // DTC history array
+    DTC_List *dict_;                                              // Pointer to DTC dictionary implementation
+    dtc_history_t errors[DIAGNOSTICS_MEMORY_SIZE];                // DTC history array
+    bool eepromLoadOk_ = false;                                   // Indicates whether last loadFromEEPROM succeeded
+    void saveEntryToEEPROM(uint8_t index);                        // Save a single entry to EEPROM
+    void saveToEEPROM();                                          // Persist memory via platform hook (no-op by default)
+    bool loadFromEEPROM();                                        // Load memory via platform hook (no-op by default). Returns true on success
+    void setStateAndPersist(uint8_t index, dtc_state_t newState); //WS Helper to set state and persist when changed
 };
+
+/*
+ * Platform persistence hooks
+ *
+ * Applications may provide their own implementations of these functions
+ * (for example in `main.cpp`) to control how diagnostics memory is
+ * persisted. If not provided, the library supplies weak default
+ * implementations that will make no operation.
+ *
+ * Signatures (hooks operate on raw bytes):
+ *  - void diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length);
+ *    -> Write `length` raw bytes starting at logical `offset` (application maps logical offset to physical storage).
+ *  - bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length);
+ *    -> Read `length` bytes into `data` from logical `offset`. Return true on success.
+ */
+void diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length);
+bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length);

--- a/firmware/lib/diagnostics/diagnostics.h
+++ b/firmware/lib/diagnostics/diagnostics.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "dtc_dict.h"
+#include <stdint.h>
+
+#ifndef DIAGNOSTICS_MEMORY_SIZE
+#warning "DIAGNOSTICS_MEMORY_SIZE is not defined by project, using default 16"
+#define DIAGNOSTICS_MEMORY_SIZE 16 // Define the size of the error history
+#endif
+
+typedef enum
+{
+    DTC_EMPTY = 0,
+    DTC_PENDING = 1,
+    DTC_ACTIVE = 2,
+    DTC_HEALING = 3,
+    DTC_HISTORY = 4
+} dtc_state_t;
+
+typedef struct
+{
+    uint8_t dtc_idx;
+    uint8_t occurrence;
+    union
+    {
+        uint8_t flags; // storage reale: [3:0]=debounce, [6:4]=state, [7]=raw
+        struct
+        {
+            unsigned debounce : 4;  // 0..15
+            unsigned state : 3;     // dtc_state_t (0..7)
+            unsigned fault_raw : 1; // 0/1
+        } bits;                     // <- comodo per debug/lettura, evita in percorsi hot
+    };
+} dtc_history_t;
+
+// Utility functions for dtc_history_t manipulation
+uint8_t dtc_get_debounce(const dtc_history_t *s);
+void dtc_set_debounce(dtc_history_t *s, uint8_t deb);
+dtc_state_t dtc_get_state(const dtc_history_t *s);
+void dtc_set_state(dtc_history_t *s, dtc_state_t st);
+bool dtc_get_raw(const dtc_history_t *s);
+void dtc_set_raw(dtc_history_t *s, bool raw);
+
+class Diagnostics
+{
+
+public:
+    /**
+     * @brief Constructor for Diagnostics system
+     * @param dict Pointer to concrete DTC_Dict implementation
+     */
+    Diagnostics(DTC_List *dict);
+
+    void setRaw(uint8_t dtc_idx, bool raw);
+    void periodic_update();
+    void clear();
+    uint8_t numberOfActiveErrors() const;
+    uint8_t numberOfErrors() const;
+    const dtc_history_t *getMemory() const { return errors; }
+    const char *getErrorDescription(uint8_t idx) const;
+    uint8_t getErrorSeverity(uint8_t idx) const;
+    uint8_t getMaxSeverity() const;
+
+private:
+    DTC_List *dict_;                               // Pointer to DTC dictionary implementation
+    dtc_history_t errors[DIAGNOSTICS_MEMORY_SIZE]; // DTC history array
+};

--- a/firmware/lib/diagnostics/diagnostics_utils.cpp
+++ b/firmware/lib/diagnostics/diagnostics_utils.cpp
@@ -1,0 +1,37 @@
+#include "diagnostics.h"
+
+// Layout flags
+#define DTC_DEB_MASK 0x0Fu
+#define DTC_STATE_MASK 0x70u
+#define DTC_STATE_SH 4
+#define DTC_RAW_MASK 0x80u
+
+uint8_t dtc_get_debounce(const dtc_history_t *s)
+{
+    return s->flags & DTC_DEB_MASK;
+}
+void dtc_set_debounce(dtc_history_t *s, uint8_t deb)
+{
+    s->flags = (s->flags & ~DTC_DEB_MASK) | (deb & DTC_DEB_MASK);
+}
+
+dtc_state_t dtc_get_state(const dtc_history_t *s)
+{
+    return (dtc_state_t)((s->flags & DTC_STATE_MASK) >> DTC_STATE_SH);
+}
+void dtc_set_state(dtc_history_t *s, dtc_state_t st)
+{
+    s->flags = (s->flags & ~DTC_STATE_MASK) | (((uint8_t)st & 0x07u) << DTC_STATE_SH);
+}
+
+bool dtc_get_raw(const dtc_history_t *s)
+{
+    return (s->flags & DTC_RAW_MASK) != 0;
+}
+void dtc_set_raw(dtc_history_t *s, bool raw)
+{
+    if (raw)
+        s->flags |= DTC_RAW_MASK;
+    else
+        s->flags &= ~DTC_RAW_MASK;
+}

--- a/firmware/lib/diagnostics/dtc_dict.h
+++ b/firmware/lib/diagnostics/dtc_dict.h
@@ -1,0 +1,75 @@
+/**
+ * @file dtc_dict.h
+ * @brief Abstract base class for DTC (Diagnostic Trouble Code) dictionary management
+ * @author Salvo Musumeci
+ * @note This abstract class must be implemented in main.cpp with concrete DTC data
+ */
+
+#pragma once
+#include <stdint.h>
+
+typedef struct __attribute__((__packed__))
+{
+    uint32_t spn;
+    uint8_t fmi;
+    const char *name;
+    uint8_t debounce_ticks;
+    uint8_t severity;
+} dtc_entity_t;
+
+/**
+ * @brief Abstract base class for DTC dictionary operations
+ * @remarks This class must be inherited and implemented with concrete DTC data in main.cpp
+ */
+class DTC_List
+{
+public:
+    /**
+     * @brief Get SPN (Suspect Parameter Number) for a DTC entry
+     * @param idx Index of the DTC entry
+     * @param out_spn Output SPN value
+     * @return true if index is valid and SPN retrieved successfully
+     */
+    virtual bool getSPN(uint16_t idx, uint32_t &out_spn) const = 0;
+
+    /**
+     * @brief Get FMI (Failure Mode Identifier) for a DTC entry
+     * @param idx Index of the DTC entry
+     * @param out_fmi Output FMI value (masked to 5 bits)
+     * @return true if index is valid and FMI retrieved successfully
+     */
+    virtual bool getFMI(uint16_t idx, uint8_t &out_fmi) const = 0;
+
+    /**
+     * @brief Get severity level for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Severity level, or 0xFF if index is invalid
+     */
+    virtual uint8_t getSeverity(uint16_t idx) const = 0;
+
+    /**
+     * @brief Get debounce ticks for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Debounce ticks, or 0xFF if index is invalid
+     */
+    virtual uint8_t getDebounceTicks(uint16_t idx) const = 0;
+
+    /**
+     * @brief Get human-readable name for a DTC entry
+     * @param idx Index of the DTC entry
+     * @return Pointer to PROGMEM string, or nullptr if index is invalid
+     */
+    virtual const char *getName(uint16_t idx) const = 0;
+
+    /**
+     * @brief Get total number of DTC entries
+     * @return Number of DTC entries in the dictionary
+     */
+    virtual uint16_t getNumberOfErrors() const = 0;
+
+    /**
+     * @brief Get magic number for EEPROM storage
+     * @return Magic number
+     */
+    virtual uint16_t getMagicNumber() const = 0;
+};

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
   -ffunction-sections            ; mette ogni funzione in una sezione separata
   -fdata-sections                ; mette ogni variabile/dato in una sezione separata
   -Wl,--gc-sections              ; linker: elimina funzioni/dati non usati
-  -Wl,-u,vfprintf -lprintf_min   ; forza printf minimale (senza float) per ridurre la flash
+  -lprintf_min                   ; forza printf minimale (senza float) per ridurre la flash
   -Wl,-Map=.pio/build/TFM_100/firmware.map  ; genera il file .map con simboli e dimensioni
 
 monitor_speed=115200

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -32,6 +32,7 @@ build_flags =
   -D J1939_PAYLOAD_POOL_SIZE=100
   -D J1939_MAX_REGISTERED_MESSAGES=10
   -D J1939_MESSAGE_QUEUE=10
+  -D DIAGNOSTICS_MEMORY_SIZE=10
   -Os                            ; ottimizza per ridurre la dimensione del codice
   -flto                          ; abilita Link Time Optimization (più riduzione codice)
   -ffunction-sections            ; mette ogni funzione in una sezione separata

--- a/firmware/src/LEDs.cpp
+++ b/firmware/src/LEDs.cpp
@@ -46,9 +46,8 @@ extern PT100 supply_sensor;      // main.cpp
 extern PT100 return_sensor;      // main.cpp
 extern Flow flowObj;             // main.cpp
 extern NodeStatus_t node_status; // main.cpp
-extern bool CANbusOff;           // main.cpp
-extern bool CANbusWarn;          // main.cpp
 extern CLIScreenManager cli;     // main.cpp
+extern uint8_t severity;         // main.cpp
 
 LEDs::LEDs(uint8_t redPin, uint8_t greenPin)
 {
@@ -153,23 +152,30 @@ void LEDs::process(bool HwFailure)
     {
         uint8_t rd_co, gr_co;
 
-        /* Decide red LED (error) output bit:
-         * - Hardware failure: use fast flicker
-         * - CAN bus off: solid ON
-         * - CAN warning: single flash pattern
-         * - PT100 sensor error: blink pattern
-         * - otherwise off
-         */
-        if (HwFailure)
-            rd_co = GenericLedStatus & LED_flicker;
-        else if (CANbusOff)
-            rd_co = 1;
-        else if (CANbusWarn)
-            rd_co = GenericLedStatus & LED_flash_1;
-        else if (supply_sensor.errorDetected || return_sensor.errorDetected)
-            rd_co = GenericLedStatus & LED_blink;
-        else
+        switch (severity)
+        {
+        case 0:
             rd_co = 0;
+            break;
+        case 1:
+            rd_co = GenericLedStatus & LED_flash_1;
+            break;
+        case 2:
+            rd_co = GenericLedStatus & LED_flash_2;
+            break;
+        case 3:
+            rd_co = GenericLedStatus & LED_flash_3;
+            break;
+        case 4:
+            rd_co = 1;
+            break;
+        case 5:
+            rd_co = GenericLedStatus & LED_blink;
+            break;
+        default:
+            rd_co = GenericLedStatus & LED_flicker;
+            break;
+        }
 
         /* Decide green LED (status) output bit:
          * - CLI connected: show 2.5Hz blink

--- a/firmware/src/cli.cpp
+++ b/firmware/src/cli.cpp
@@ -7,6 +7,7 @@
 #include <mcp_can.h>
 #include <MAX31865_NonBlocking.h>
 #include <diagnostics.h>
+#include <utils.h>
 
 // External variables
 extern PT100 supply_sensor; // main.cpp
@@ -16,48 +17,6 @@ extern Scheduler scheduler; // main.cpp
 extern uint8_t node_id;     // main.cpp
 extern MCP_CAN CAN0;        // main.cpp
 extern Diagnostics DSM;     // main.cpp
-
-/**
- * @brief Converts a float to string with specified decimals, minimal RAM usage.
- * @param buf Output buffer (must be large enough)
- * @param f Float value to convert
- * @param decimals Number of decimal places
- * @return None
- * @remarks Uses integer math, no heap, buffer must be at least 12 bytes for 2 decimals.
- */
-void ftostr(char *buf, float f, int decimals)
-{
-    int32_t mult = 1;
-    for (int i = 0; i < decimals; ++i)
-        mult *= 10;
-    int32_t value = (int32_t)(f * mult + (f < 0 ? -0.5f : 0.5f));
-    int32_t int_part = value / mult;
-    int32_t frac_part = abs(value % mult);
-
-    // Print integer part
-    char *p = buf;
-    if (int_part < 0)
-    {
-        *p++ = '-';
-        int_part = -int_part;
-    }
-    itoa(int_part, p, 10);
-    while (*p)
-        ++p;
-
-    // Print decimal part
-    if (decimals > 0)
-    {
-        *p++ = '.';
-        int pow10 = mult / 10;
-        for (int i = 0; i < decimals; ++i)
-        {
-            *p++ = '0' + (frac_part / pow10) % 10;
-            pow10 /= 10;
-        }
-    }
-    *p = '\0';
-}
 
 // Constructor
 CLIScreenManager::CLIScreenManager(Stream *stream, uint16_t width, uint16_t height)
@@ -610,7 +569,7 @@ void CLIScreenManager::logMessage(const __FlashStringHelper *message, LogType se
 
     // Stampa il timestamp a 10 caratteri, padding a sinistra con zeri
     char timestamp[11];
-    snprintf(timestamp, sizeof(timestamp), "%4lu", (uint32_t)(millis() / 1000));
+    mini_udec_padded(timestamp, (uint32_t)(millis() / 1000), 4);
     ansi->print(timestamp);
     ansi->foreground(color);
     ansi->bold();
@@ -658,7 +617,7 @@ void CLIScreenManager::logMessage(const char *message, LogType severity)
 
     // Stampa il timestamp a 10 caratteri, padding a sinistra con zeri
     char timestamp[11];
-    snprintf(timestamp, sizeof(timestamp), "%4lu", (uint32_t)(millis() / 1000));
+    mini_udec_padded(timestamp, (uint32_t)(millis() / 1000), 4);
     ansi->print(timestamp);
     ansi->foreground(color);
     ansi->bold();

--- a/firmware/src/cli.cpp
+++ b/firmware/src/cli.cpp
@@ -6,6 +6,7 @@
 #include <scheduler.h>
 #include <mcp_can.h>
 #include <MAX31865_NonBlocking.h>
+#include <diagnostics.h>
 
 // External variables
 extern PT100 supply_sensor; // main.cpp
@@ -14,6 +15,7 @@ extern Flow flowObj;        // main.cpp
 extern Scheduler scheduler; // main.cpp
 extern uint8_t node_id;     // main.cpp
 extern MCP_CAN CAN0;        // main.cpp
+extern Diagnostics DSM;     // main.cpp
 
 /**
  * @brief Converts a float to string with specified decimals, minimal RAM usage.
@@ -183,13 +185,13 @@ void CLIScreenManager::process()
             drawRealTimeSignals(full_update);
             break;
         case ScreenType::DIAGNOSTICS:
-            drawDiagnosticsScreen();
+            drawDiagnosticsScreen(full_update, input);
             break;
         case ScreenType::SYSTEM_INFO:
-            drawSystemInfoScreen();
+            drawSystemInfoScreen(full_update);
             break;
         case ScreenType::CALIBRATION:
-            drawCalibrationScreen(input);
+            drawCalibrationScreen(full_update, input);
             break;
         case ScreenType::LOG:
             drawLogScreen(full_update);
@@ -343,15 +345,142 @@ void CLIScreenManager::drawRealTimeSignals(bool full_update)
     ansi->print(" hours   ");
 }
 
-void CLIScreenManager::drawDiagnosticsScreen(bool full_update)
+void CLIScreenManager::drawDiagnosticsScreen(bool full_update, char input)
 {
+    static bool no_errors = true;
     if (!ansi_enabled)
         return;
 
-    printHeader(F("TFM-100 - MEMORIA ERRORI"));
-    printSeparator('=');
+    // Handle input for reset errors
+    if (input == 'r' || input == 'R')
+        DSM.clear();
 
-    ansi->gotoXY(1, 4);
+    if (full_update)
+    {
+        printHeader(F("TFM-100 - MEMORIA ERRORI"));
+        printSeparator('=');
+
+        // Print table header using printTable style
+        ansi->foreground(ansi->yellow);
+        ansi->bold();
+        ansi->print(F("ID\tError Description\t\tState\t\tSeverity\tOcc."));
+        ansi->normal();
+        ansi->println();
+        printSeparator('-');
+    }
+
+    /* Show Diagnostics Data in Table Format */
+    const dtc_history_t *errors = DSM.getMemory();
+    uint8_t numberOfStoredErrors = DSM.numberOfErrors();
+
+    // Erase old printed area
+    clearArea(5 + numberOfStoredErrors, 5 + DIAGNOSTICS_MEMORY_SIZE);
+    ansi->gotoXY(1, 5);
+    if (numberOfStoredErrors == 0)
+    {
+        ansi->println(F("No errors stored in memory"));
+    }
+    else
+    {
+        if (no_errors)
+            ansi->clearLine(ansi->entireLine);
+        // Print table rows
+        for (uint8_t i = 0; i < DIAGNOSTICS_MEMORY_SIZE; i++)
+        {
+            if (dtc_get_state(&errors[i]) != DTC_EMPTY)
+            {
+                // ID column (cyan color like printTable)
+                ansi->foreground(ansi->cyan);
+                ansi->print(i);
+                ansi->normal();
+                ansi->print(F("\t"));
+
+                // Error Description column (white color)
+                ansi->foreground(ansi->white);
+                const char *description = DSM.getErrorDescription(i);
+                if (description)
+                {
+                    ansi->print(description);
+                }
+                else
+                {
+                    ansi->print(F("Unknown DTC"));
+                }
+                ansi->normal();
+                ansi->print(F("\t\t"));
+
+                // State column (white color)
+                ansi->foreground(ansi->white);
+                switch (dtc_get_state(&errors[i]))
+                {
+                case DTC_PENDING:
+                    ansi->print(F("Pending"));
+                    break;
+                case DTC_ACTIVE:
+                    ansi->print(F("Active "));
+                    break;
+                case DTC_HEALING:
+                    ansi->print(F("Healing"));
+                    break;
+                case DTC_HISTORY:
+                    ansi->print(F("History"));
+                    break;
+                default:
+                    ansi->print(F("Unknown"));
+                    break;
+                }
+                ansi->normal();
+                ansi->print(F("\t\t"));
+
+                // Severity column (color-coded by severity level)
+                uint8_t severity = DSM.getErrorSeverity(i);
+                if (severity != 0xFF)
+                {
+                    // Color-code severity: 1=white, 2-4=red 5+=background red
+                    if (severity < 1)
+                        ansi->foreground(ansi->white);
+                    else if (severity < 4)
+                        ansi->foreground(ansi->red);
+                    else
+                    {
+                        ansi->background(ansi->red);
+                        ansi->foreground(ansi->white);
+                    }
+                    ansi->print("  ");
+                    ansi->print(severity);
+                    ansi->print("  ");
+                }
+                else
+                {
+                    ansi->foreground(ansi->white);
+                    ansi->print(F("?"));
+                }
+                ansi->normal();
+                ansi->print(F("\t\t"));
+
+                // Occurrences column (white color)
+                ansi->foreground(ansi->white);
+                ansi->print(errors[i].occurrence);
+                ansi->normal();
+                ansi->println();
+            }
+        }
+    }
+
+    if (full_update)
+    {
+        ansi->gotoXY(1, terminal_height - 2);
+        printSeparator('-');
+        printMenuFooter();
+    }
+    ansi->gotoXY(1, terminal_height - 3);
+    ansi->print(F("Total errors: "));
+    ansi->print(numberOfStoredErrors);
+    ansi->print(F(" | Active: "));
+    ansi->print(DSM.numberOfActiveErrors());
+    ansi->println(F("\tPress 'R' to reset errors"));
+
+    no_errors = (numberOfStoredErrors == 0);
 }
 
 void CLIScreenManager::drawSystemInfoScreen(bool full_update)
@@ -366,7 +495,6 @@ void CLIScreenManager::drawSystemInfoScreen(bool full_update)
 
         printFooter();
     }
-    char buf[10];
     ansi->gotoXY(1, 4);
     /* Show data for PT100 sensors */
     MAX31865 *sensor;
@@ -599,47 +727,6 @@ void CLIScreenManager::printProgressBar(uint8_t progress, uint8_t width, const _
     ansi->println("%");
 }
 
-void CLIScreenManager::printTable(const __FlashStringHelper *headers[], const __FlashStringHelper *data[][2], uint8_t rows, uint8_t cols)
-{
-    if (!ansi_enabled)
-        return;
-
-    // Stampa header
-    ansi->foreground(ansi->yellow);
-    ansi->bold();
-    for (uint8_t c = 0; c < cols; c++)
-    {
-        ansi->print(headers[c]);
-        if (c < cols - 1)
-            ansi->print("\t\t");
-    }
-    ansi->normal();
-    ansi->println();
-
-    printSeparator('-');
-
-    // Stampa dati
-    for (uint8_t r = 0; r < rows; r++)
-    {
-        for (uint8_t c = 0; c < cols; c++)
-        {
-            if (c == 0)
-            {
-                ansi->foreground(ansi->cyan);
-            }
-            else
-            {
-                ansi->foreground(ansi->white);
-            }
-            ansi->print(data[r][c]);
-            ansi->normal();
-            if (c < cols - 1)
-                ansi->print("\t\t");
-        }
-        ansi->println();
-    }
-}
-
 /**
  * @brief Prints a status indicator with label and status, using ANSI colors.
  * @param label Status label (const __FlashStringHelper*)
@@ -753,7 +840,7 @@ void CLIScreenManager::printSeparator(char character)
 
 void CLIScreenManager::printFooter(bool failure)
 {
-    ansi->gotoXY(1, terminal_height - 2);
+    ansi->gotoXY(1, terminal_height - 3);
     printSeparator('-');
     ansi->foreground(ansi->yellow);
     ansi->print(F("Firmware v"));
@@ -771,5 +858,11 @@ void CLIScreenManager::printFooter(bool failure)
     }
     else
         // Istruzioni di navigazione
-        ansi->print(F("Navigazione: Valori (V) | Device (D) | Errori (E) | Calibrazione (C) | Log (L)"));
+        printMenuFooter();
+}
+
+void CLIScreenManager::printMenuFooter()
+{
+    ansi->gotoXY(1, terminal_height - 1);
+    ansi->print(F("Navigazione: Valori (V) | Device (D) | Errori (E) | Calibrazione (C) | Log (L)"));
 }

--- a/firmware/src/dm1_implementation.cpp
+++ b/firmware/src/dm1_implementation.cpp
@@ -1,0 +1,53 @@
+#include "stdint.h"
+#include <J1939_DM.h>
+#include <diagnostics.h>
+#include <dtc.h>
+
+extern Diagnostics DSM;                   // Diagnostics manager instance (defined in main.cpp)
+extern TFM100_DTC_Dict dtc_dict_instance; // DTC dictionary instance (defined in main.cpp)
+
+// Implement J1939 DM1 harness functions
+uint8_t J1939_DM::getNumberOfActiveErrors()
+{
+    return (uint8_t)DSM.numberOfActiveErrors();
+}
+
+void J1939_DM::getErrorCode(uint8_t index, uint32_t &spn, uint8_t &fmi, uint8_t &oc)
+{
+    const uint8_t idx = DSM.getIndexForActiveErrorAt(index);
+    dtc_dict_instance.getSPN(idx, spn);
+    dtc_dict_instance.getFMI(idx, fmi);
+    oc = DSM.getOccurrenceCount(index);
+}
+
+J1939_DM::LampStatus J1939_DM::getWarningLampStatus()
+{
+    uint8_t severity = DSM.getMaxSeverity();
+    switch (severity)
+    {
+    case red_lamp_state_t::ONE_BLINK:
+        return J1939_DM::LampStatus::SOLID;
+    case red_lamp_state_t::TWO_BLINKS:
+        return J1939_DM::LampStatus::SLOW_BLINK;
+    case red_lamp_state_t::THREE_BLINKS:
+        return J1939_DM::LampStatus::FAST_BLINK;
+    default:
+        return J1939_DM::LampStatus::OFF;
+    }
+}
+
+J1939_DM::LampStatus J1939_DM::getStopLampStatus()
+{
+    uint8_t severity = DSM.getMaxSeverity();
+    switch (severity)
+    {
+    case red_lamp_state_t::SOLID:
+        return J1939_DM::LampStatus::SOLID;
+    case red_lamp_state_t::FLASHING:
+        return J1939_DM::LampStatus::SLOW_BLINK;
+    case red_lamp_state_t::FLICKERING:
+        return J1939_DM::LampStatus::FAST_BLINK;
+    default:
+        return J1939_DM::LampStatus::OFF;
+    }
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -38,6 +38,7 @@
 #include <dip_switch.h>
 #include <dtc.h>
 #include <EEPROM.h>
+#include <utils.h>
 
 /* CLI */
 CLIScreenManager cli = CLIScreenManager();
@@ -120,8 +121,14 @@ bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length)
 static void j1939_on_error(const J1939Descriptor &desc)
 {
   char buf[80];
-  // Format PGN in hex with leading 0x
-  snprintf(buf, sizeof(buf), "J1939 TX ERROR PGN=0x%06lX ", (unsigned long)desc.pgn);
+  // Format PGN in hex with leading 0x using minimal formatter then append message
+  mini_hex6(buf, (unsigned long)desc.pgn); // produces 0xNNNNNN\0
+  // Append message text after the hex
+  char *p = buf + 8;
+  const char *msg = " J1939 TX ERROR";
+  while (*msg)
+    *p++ = *msg++;
+  *p = '\0';
   cli.logError(buf);
 }
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -16,6 +16,7 @@
 #include <SPI.h>
 #include "config.h"
 #include <avr/wdt.h>
+#include <MAX31865_NonBlocking.h>
 
 // MyLib
 #include <scheduler.h>
@@ -23,6 +24,7 @@
 #include <PT100.h>
 #include <flow.h>
 #include <J1939Manager.h>
+#include <diagnostics.h>
 
 // 3rd parties lib
 #include <mcp_can.h>
@@ -33,6 +35,7 @@
 #include <can_messages.h>
 #include <McpCanAdapter.h>
 #include <dip_switch.h>
+#include <dtc.h>
 
 /* CLI */
 CLIScreenManager cli = CLIScreenManager();
@@ -66,6 +69,7 @@ Scheduler scheduler = Scheduler();
 
 /* Node ID */
 uint8_t node_id;
+uint8_t severity = 0;
 
 bool CANbusOff = false;
 bool CANbusWarn = false;
@@ -76,6 +80,10 @@ HeartbeatMessage HBMessage = HeartbeatMessage(5000); // 5s interval
 CAN_Temperature TempMessage = CAN_Temperature();
 CAN_FilteredTemperatureAndFlow TempAndFlowMessage = CAN_FilteredTemperatureAndFlow();
 
+/* Diagnostics */
+TFM100_DTC_Dict dtc_dict_instance = TFM100_DTC_Dict();
+Diagnostics DSM = Diagnostics(&dtc_dict_instance);
+
 // Forward declaration of J1939Descriptor is available via J1939Manager.h
 // Provide a simple error callback to forward J1939 manager errors to CLI
 static void j1939_on_error(const J1939Descriptor &desc)
@@ -85,6 +93,8 @@ static void j1939_on_error(const J1939Descriptor &desc)
   snprintf(buf, sizeof(buf), "J1939 TX ERROR PGN=0x%06lX ", (unsigned long)desc.pgn);
   cli.logError(buf);
 }
+
+void update_errors();
 
 void setup()
 {
@@ -132,6 +142,10 @@ void setup()
   // If any critical subsystem is not initialized, show hardware failure UI and reboot
   if (!mcp_normal || !supply_init || !return_init)
   {
+    DSM.setRaw(DTC_SupplyLineDeviceError, supply_init == false);
+    DSM.setRaw(DTC_ReturnLineDeviceError, return_init == false);
+    DSM.setRaw(DTC_CANBusDeviceError, mcp_normal == false);
+
     node_status = STOP;
     bool reboot_now = false;
     while (millis() < 60000 && !reboot_now)
@@ -139,6 +153,7 @@ void setup()
       // drawHardwareFailure returns true when user requests immediate reboot
       reboot_now = cli.drawHardwareFailure(mcp_init, mcp_normal, supply_init, return_init);
       // Keep LED state machine ticking and allow scheduled tasks to run
+      severity = DSM.getMaxSeverity();
       ledIndicators.process(true);
       scheduler.run();
     }
@@ -176,8 +191,35 @@ void setup()
                     { cli.periodic(); },
                     1000);
 
+  // Periodic diagnostics update (check sensor errors, update DTC memory)
+  scheduler.addTask([](uint32_t td)
+                    { update_errors(); },
+                    1000);
+
   // All initialization succeeded, enter RUN state
   node_status = RUN;
+}
+
+void update_errors()
+{
+  // Supply Sensor Errors
+  DSM.setRaw(DTC_SupplyLineRefInHigh, supply_sensor.last_fault & MAX31865::FAULT_HIGHTHRESH_BIT);
+  DSM.setRaw(DTC_SupplyLineRefInLow, supply_sensor.last_fault & MAX31865::FAULT_LOWTHRESH_BIT);
+  DSM.setRaw(DTC_SupplyLineRtdInLow, supply_sensor.last_fault & MAX31865::FAULT_RTDINLOW_BIT);
+  DSM.setRaw(DTC_SupplyLineUOV, supply_sensor.last_fault & MAX31865::FAULT_OVUV_BIT);
+
+  // Return Sensor Errors
+  DSM.setRaw(DTC_ReturnLineRefInHigh, return_sensor.last_fault & MAX31865::FAULT_HIGHTHRESH_BIT);
+  DSM.setRaw(DTC_ReturnLineRefInLow, return_sensor.last_fault & MAX31865::FAULT_LOWTHRESH_BIT);
+  DSM.setRaw(DTC_ReturnLineRtdInLow, return_sensor.last_fault & MAX31865::FAULT_RTDINLOW_BIT);
+  DSM.setRaw(DTC_ReturnLineUOV, return_sensor.last_fault & MAX31865::FAULT_OVUV_BIT);
+
+  // CAN Bus Errors
+  DSM.setRaw(DTC_CANBusOff, CANbusOff);
+  DSM.setRaw(DTC_CANBusErrorPassive, CANbusWarn);
+
+  DSM.periodic_update();
+  severity = DSM.getMaxSeverity();
 }
 
 void loop()

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -24,6 +24,7 @@
 #include <PT100.h>
 #include <flow.h>
 #include <J1939Manager.h>
+#include <J1939_DM.h>
 #include <diagnostics.h>
 
 // 3rd parties lib
@@ -79,6 +80,7 @@ bool HwFailure = true; // Assume HW failure until all init done
 HeartbeatMessage HBMessage = HeartbeatMessage(5000); // 5s interval
 CAN_Temperature TempMessage = CAN_Temperature();
 CAN_FilteredTemperatureAndFlow TempAndFlowMessage = CAN_FilteredTemperatureAndFlow();
+J1939_DM1Message DM1 = J1939_DM1Message(1000); // 1s interval
 
 /* Diagnostics */
 TFM100_DTC_Dict dtc_dict_instance = TFM100_DTC_Dict();
@@ -176,6 +178,7 @@ void setup()
   j1939->registerMessage(&HBMessage);
   j1939->registerMessage(&TempMessage);
   j1939->registerMessage(&TempAndFlowMessage);
+  j1939->registerMessage(&DM1);
 
   // Schedule periodic PT100 measurements (driver triggers non-blocking measurement)
   scheduler.addTask([](uint32_t td)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -37,6 +37,7 @@
 #include <McpCanAdapter.h>
 #include <dip_switch.h>
 #include <dtc.h>
+#include <EEPROM.h>
 
 /* CLI */
 CLIScreenManager cli = CLIScreenManager();
@@ -86,6 +87,34 @@ J1939_DM1Message DM1 = J1939_DM1Message(1000); // 1s interval
 TFM100_DTC_Dict dtc_dict_instance = TFM100_DTC_Dict();
 Diagnostics DSM = Diagnostics(&dtc_dict_instance);
 
+// -----------------------------------------------------------------------------
+// Persistence hooks (default application implementation using AVR EEPROM)
+// These implement the required low-level write/read of raw bytes at a
+// logical offset. The library composes logical offsets starting at 0 for
+// diagnostics; we map them to physical EEPROM addresses by adding
+// DIAGNOSTICS_EEPROM_OFFSET.
+// -----------------------------------------------------------------------------
+void diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length)
+{
+  uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
+  for (uint8_t i = 0; i < length; i++)
+  {
+    uint8_t v = data[i];
+    // EEPROM.update writes only if value differs, minimizing wear
+    EEPROM.update(phys + i, v);
+  }
+}
+
+bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length)
+{
+  uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
+  for (uint8_t i = 0; i < length; i++)
+  {
+    data[i] = EEPROM.read(phys + i);
+  }
+  return true; // read always succeeds (caller is responsible for magic validation)
+}
+
 // Forward declaration of J1939Descriptor is available via J1939Manager.h
 // Provide a simple error callback to forward J1939 manager errors to CLI
 static void j1939_on_error(const J1939Descriptor &desc)
@@ -117,6 +146,9 @@ void setup()
   // Serial for CLI/diagnostics output
   Serial.begin(115200);
   cli.begin();
+
+  // If diagnostics EEPROM load failed during Diagnostics construction, flag the DTC
+  DSM.setRaw(DTC_DSMEepromFailure, !DSM.eepromLoadOk());
 
   // Compute node address from DIP switches (base + switch value)
   node_id = dip_switch_read() | NODE_ID_BASE;


### PR DESCRIPTION
This pull request introduces several improvements and new features related to diagnostics, CAN bus communication, and utility functions in the firmware. The most significant changes include the addition of a comprehensive Diagnostic Trouble Code (DTC) dictionary and management system, enhancements to J1939 CAN protocol support for diagnostics messages (DM1), and utility functions for string formatting. There are also minor API adjustments and configuration updates for EEPROM storage.

**Diagnostics and DTC Management:**
* Added a new DTC dictionary and management class `TFM100_DTC_Dict` in `dtc.h`, including enums for DTCs and lamp states, a PROGMEM-based lookup table, and methods for retrieving DTC properties. This provides a structured approach to handling diagnostic codes and their metadata.
* Defined EEPROM offset for diagnostics storage in `config.h` to reserve space for DTC-related data.

**J1939 CAN Protocol Enhancements:**
* Implemented J1939 DM1 message support in `J1939_DM.h` and `J1939_DM.cpp`, including lamp status encoding and error code reporting. Added weak functions for error and lamp status retrieval to allow flexible integration. [[1]](diffhunk://#diff-bc34335e7e876a910c2aa867ffb5cc67a8fcd23b9d11fb7933c85d49e7124422R1-R39) [[2]](diffhunk://#diff-625ecf844c077a9bc830dc8ab654ed955a2b00af032a645bb5fc4e4d60ebf3a6R1-R123)
* Updated PGN values for BAM and DT frames in `J1939Manager.cpp` to use broadcast PGNs (`0xECFF` and `0xEBFF`), and ensured DT frames are padded to 8 bytes for better interoperability. [[1]](diffhunk://#diff-c9c7b3b31ecc227039594edd8c547f63464737f171a1dd86de144b38ff4e395cL238-R238) [[2]](diffhunk://#diff-c9c7b3b31ecc227039594edd8c547f63464737f171a1dd86de144b38ff4e395cL270-R285)

**Utility Functions:**
* Added lightweight string formatting helpers in `utils.h` for hexadecimal, padded decimal, and float-to-string conversion, minimizing code size and memory usage.

**CLI Screen Manager API Updates:**
* Added `printMenuFooter()` and updated method signatures in `cli.h` to support new UI features and input handling for diagnostics and calibration screens. [[1]](diffhunk://#diff-233e1224b654e430d6d352a31ee3a4eaf1c9f77fe9a13228c574c1ceb23376b7R44) [[2]](diffhunk://#diff-233e1224b654e430d6d352a31ee3a4eaf1c9f77fe9a13228c574c1ceb23376b7L73-R74)