### PR TITLE
Feature/calculate energy

### DIFF
--- a/firmware/include/can_messages.h
+++ b/firmware/include/can_messages.h
@@ -17,3 +17,4 @@
 #include <messages/HeartbeatMessage.h>
 #include <messages/FilteredTemperatureMessage.h>
 #include <messages/RawTemperatureMessage.h>
+#include <messages/PowerAndEnergy.h>

--- a/firmware/include/cli.h
+++ b/firmware/include/cli.h
@@ -34,9 +34,6 @@ private:
     bool periodic_update;
     uint8_t logRow = 0;
 
-    // FIXME: remove these variables
-    float power, power_percentage, energy_24h, energy_total;
-
     // Metodi privati per la formattazione
     void printHeader(const __FlashStringHelper *title, uint8_t background = 255, uint8_t foreground = 255);
     void printFooter(bool failure = false);

--- a/firmware/include/config.h
+++ b/firmware/include/config.h
@@ -34,4 +34,6 @@
 
 // EEPROM layout
 // First byte reserved for diagnostics storage start (logical offset)
+#define POWER_EEPROM_OFFSET 0x1A
+#define ENERGY_EEPROM_OFFSET 0x20
 #define DIAGNOSTICS_EEPROM_OFFSET 0x40

--- a/firmware/include/config.h
+++ b/firmware/include/config.h
@@ -34,6 +34,24 @@
 
 // EEPROM layout
 // First byte reserved for diagnostics storage start (logical offset)
+//
+// Layout (byte offsets, inclusive ranges):
+//   0x00           : reserved (logical diagnostics start pointer)
+//   0x1A - 0x1F    : POWER region (6 bytes: 2 bytes magic + 4 bytes max_power)
+//   0x20 - 0x29    : ENERGY region (10 bytes: 2 bytes magic + 4 bytes energy_total + 4 bytes energy_24h)
+//   0x40 - ...     : DIAGNOSTICS region (starts at 0x40; size defined elsewhere)
+//
+// Offsets:
 #define POWER_EEPROM_OFFSET 0x1A
 #define ENERGY_EEPROM_OFFSET 0x20
 #define DIAGNOSTICS_EEPROM_OFFSET 0x40
+
+// Region sizes (in bytes) — keep in sync with EEPROM data structures:
+#define POWER_EEPROM_SIZE   6   // 2 bytes magic + 4 bytes max_power
+#define ENERGY_EEPROM_SIZE 10   // 2 bytes magic + 4 bytes energy_total + 4 bytes energy_24h
+
+// Compile-time checks to ensure EEPROM regions do not overlap.
+static_assert(POWER_EEPROM_OFFSET + POWER_EEPROM_SIZE <= ENERGY_EEPROM_OFFSET,
+              "EEPROM layout error: POWER region overlaps ENERGY region");
+static_assert(ENERGY_EEPROM_OFFSET + ENERGY_EEPROM_SIZE <= DIAGNOSTICS_EEPROM_OFFSET,
+              "EEPROM layout error: ENERGY region overlaps DIAGNOSTICS region");

--- a/firmware/include/diag_comm.h
+++ b/firmware/include/diag_comm.h
@@ -8,11 +8,13 @@
 #include "flow.h"
 #include "status.h"
 #include "config.h"
+#include "energy.h"
 
 extern Diagnostics DSM;
 extern PT100 supply_sensor;
 extern PT100 return_sensor;
 extern Flow flowObj;
+extern Energy energyObj;
 extern NodeStatus_t node_status;
 extern uint8_t node_id;
 

--- a/firmware/include/diag_comm.h
+++ b/firmware/include/diag_comm.h
@@ -66,6 +66,7 @@ public:
 private:
     bool clientConnected = false;
     void send_complete_diagnostics();
-    static SerialProtocol comm;  // --- Serial protocol instance ---
-    static DiagComm *s_instance; // trampoline instance for static callbacks
+    static SerialProtocol comm;       // --- Serial protocol instance ---
+    static DiagComm *s_instance;      // trampoline instance for static callbacks
+    static uint32_t last_diag_update; // timestamp of last periodic update
 };

--- a/firmware/include/dtc.h
+++ b/firmware/include/dtc.h
@@ -26,6 +26,8 @@ typedef enum
     DTC_CANBusOff,
     DTC_CANBusErrorPassive,
     DTC_CANBusDeviceError,
+    DTC_EnergyEepromFailure,
+    DTC_PowerEepromFailure
 
 } dtc_enum_t;
 
@@ -58,6 +60,8 @@ const char DTC_ReturnLineDeviceError_[] PROGMEM = "DTC_ReturnLineDeviceError";
 const char DTC_CANBusOff_[] PROGMEM = "DTC_CANBusErrorBusOff";
 const char DTC_CANBusErrorPassive_[] PROGMEM = "DTC_CANBusErrorPassive";
 const char DTC_CANBusDeviceError_[] PROGMEM = "DTC_CANBusDeviceError";
+const char DTC_EnergyEepromFailure_[] PROGMEM = "DTC_EnergyEepromFailure";
+const char DTC_PowerEepromFailure_[] PROGMEM = "DTC_PowerEepromFailure";
 // // Add more strings as needed
 
 const dtc_entity_t dtc_dict_entries[] PROGMEM = {
@@ -82,6 +86,9 @@ const dtc_entity_t dtc_dict_entries[] PROGMEM = {
     {639, 12, DTC_CANBusOff_, 5, red_lamp_state_t::THREE_BLINKS},       // DTC_CANBusOff
     {639, 2, DTC_CANBusErrorPassive_, 5, red_lamp_state_t::SOLID},      // DTC_CANBusErrorPassive
     {639, 23, DTC_CANBusDeviceError_, 0, red_lamp_state_t::FLICKERING}, // DTC_CANBusDeviceError
+
+    {523701, 0, DTC_EnergyEepromFailure_, 0, red_lamp_state_t::ONE_BLINK}, // DTC_EnergyEepromFailure (energy EEPROM failure)
+    {523702, 0, DTC_PowerEepromFailure_, 0, red_lamp_state_t::ONE_BLINK},  // DTC_PowerEepromFailure (power EEPROM failure)
 
     // Add more DTC definitions as needed
 };

--- a/firmware/include/energy.h
+++ b/firmware/include/energy.h
@@ -1,0 +1,141 @@
+#include "Arduino.h"
+#include "config.h"
+
+#pragma once
+
+/**
+ * @file energy.h
+ * @brief Energy calculation helpers and persistence for the TFM-100 firmware.
+ * @author Salvo Musumeci
+ * @note All functions use the following units unless otherwise stated:
+ *  - Temperature: degrees Celsius (°C)
+ *  - Volume: litres (L)
+ *  - Flow: litres per hour (L/h)
+ *  - Specific heat capacity: kJ/(kg·K)
+ *  - Density: kg/L
+ *  - Power returned in kilowatts (kW)
+ *  - Energy returned/stored in kilowatt-hours (kWh)
+ */
+
+// Physical constants (water) used by the simple energy calculations.
+// Use temperature-dependent values for higher metering accuracy if required.
+#define cp 4.186f    // kJ/kg°C for water
+#define density 1.0f // kg/L for water
+
+/**
+ * @brief Compute instantaneous thermal power.
+ * @param supply_temp_degC Supply temperature in °C
+ * @param return_temp_degC Return temperature in °C
+ * @param flow_lph Volumetric flow in litres per hour (L/h)
+ * @return Thermal power in kilowatts (kW). Signed: positive means heat delivered when supply > return.
+ *
+ * Units:
+ * - cp: kJ/(kg·K)
+ * - density: kg/L
+ * - L/h -> kg/h -> kJ/h -> kJ/s -> kW (divide by 3600)
+ */
+inline float getThermalPower(float supply_temp, float return_temp, float flow_lph)
+{
+    const float seconds_per_hour = 3600.0f;
+
+    float delta_t = supply_temp - return_temp;
+
+    // optional deadband to avoid noise integration
+    const float DT_DEADBAND = 0.05f; // °C
+    if (fabs(delta_t) < DT_DEADBAND)
+        delta_t = 0.0f;
+
+    // return signed power (positive when supply > return)
+    return (flow_lph * density * cp * delta_t) / seconds_per_hour;
+}
+
+/**
+ * @brief Compute energy increment (kWh) from measured volume.
+ * @param supply_temp_degC Supply temperature in °C
+ * @param return_temp_degC Return temperature in °C
+ * @param volume_liters Volume passed since last sample in liters
+ * @return energy increment in kWh
+ */
+inline float energyFromVolume_kWh(float supply_temp_degC, float return_temp_degC, float volume_liters)
+{
+    float delta_t = supply_temp_degC - return_temp_degC;
+    float energy_kJ = volume_liters * density * cp * delta_t; // kJ
+    float energy_kWh = energy_kJ / 3600.0f;                   // kWh (since 1 kWh = 3600 kJ)
+    return energy_kWh;
+}
+
+class Energy
+{
+public:
+    Energy()
+    {
+        // Attempt to load persisted state from EEPROM
+        if (!loadFromEEPROM())
+        {
+            // No valid data, start from zero
+            energy_24h = 0.0f;
+            energy_total = 0.0f;
+            saveToEEPROM(true); // write magic
+        }
+    }
+
+    /**
+     * @brief Increase stored energy counters using measured volume.
+     * @param supply_temp Supply temperature in °C
+     * @param return_temp Return temperature in °C
+     * @param volume_liters Volume passed since last sample in litres
+     * @remarks energy values are stored in kWh
+     */
+    void increase_energy(float supply_temp, float return_temp, float volume_liters);
+
+    /** @brief Return energy consumed in the last 24 hours (kWh) */
+    float getEnergy24h() { return energy_24h; }
+    /** @brief Return total accumulated energy (kWh) */
+    float getEnergyTotal() { return energy_total; }
+
+    /** @brief Return true if last EEPROM load failed (data invalid) */
+    bool hasEepromFailure() { return eeprom_failure; }
+
+    /**
+     * @brief Reset both 24h and total energy and persist to EEPROM
+     */
+    void resetAll()
+    {
+        energy_24h = 0.0f;
+        energy_total = 0.0f;
+        saveToEEPROM();
+    }
+
+    /** @brief Reset only the 24h energy counter and persist */
+    void reset24h()
+    {
+        energy_24h = 0.0f;
+        saveToEEPROM();
+    }
+
+private:
+    const uint16_t magic = 0x1943; // Magic number to validate EEPROM data
+
+    float energy_24h = 0.0f;     // Energy consumed in last 24 hours (kWh)
+    float energy_total = 0.0f;   // Total energy consumed (kWh)
+    bool eeprom_failure = false; // True if last EEPROM load failed
+
+    enum EEPROM_Layout
+    {
+        EEPROM_MAGIC = 0,
+        EEPROM_ENERGY_TOTAL = 2,
+        EEPROM_ENERGY_24H = 6,
+    };
+
+    /**
+     * @brief Load persisted energy state from EEPROM into this instance
+     * @return true if valid data was loaded (magic matches), false otherwise
+     */
+    bool loadFromEEPROM();
+
+    /**
+     * @brief Persist current energy state into EEPROM
+     * @return true on success
+     */
+    bool saveToEEPROM(bool update_magic = false);
+};

--- a/firmware/include/energy.h
+++ b/firmware/include/energy.h
@@ -93,8 +93,12 @@ public:
     /** @brief Return total accumulated energy (kWh) */
     float getEnergyTotal() { return energy_total; }
 
-    /** @brief Return true if last EEPROM load failed (data invalid) */
-    bool hasEepromFailure() { return eeprom_failure; }
+    /**
+     * @brief Check if EEPROM load was successful.
+     * @return true if EEPROM data was loaded correctly, false otherwise
+     * @remarks Returns false if last EEPROM load failed or data was invalid.
+     */
+    bool eepromLoadOk() const { return !eeprom_failure; }
 
     /**
      * @brief Reset both 24h and total energy and persist to EEPROM

--- a/firmware/include/messages/PowerAndEnergy.h
+++ b/firmware/include/messages/PowerAndEnergy.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <J1939Manager.h>
+
+/**
+ * @file PowerAndEnergyMessage.h
+ * @brief Periodic power and energy message.
+ *
+ * Combines power and energy data into a single PGN.
+ * Intended to be registered with the `J1939Manager` as a `PeriodicMessage`.
+ */
+class CAN_PowerAndEnergy : public PeriodicMessage
+{
+public:
+    /**
+     * @brief Construct with optional transmit interval.
+     * @param interval_ms Interval between transmissions in milliseconds.
+     */
+    CAN_PowerAndEnergy(uint16_t interval_ms = 1000) : PeriodicMessage(interval_ms) {}
+
+    /** @brief PGN for power and energy message. */
+    uint32_t getPGN() override { return 0xFF13; }
+
+    /**
+     * @brief Build combined payload for power and energy.
+     *
+     * Manager will perform a copy of the returned payload when
+     * `shallPayloadCopied()` returns true.
+     */
+    uint8_t *buildPayload(uint8_t *len) override;
+
+    /** @brief Use COPY mode for payloads. */
+    bool shallPayloadCopied() override { return true; }
+};

--- a/firmware/include/power.h
+++ b/firmware/include/power.h
@@ -1,0 +1,138 @@
+#include "Arduino.h"
+#include "config.h"
+
+#pragma once
+
+/**
+ * @file energy.h
+ * @brief Energy calculation helpers and persistence for the TFM-100 firmware.
+ * @author Salvo Musumeci
+ * @note All functions use the following units unless otherwise stated:
+ *  - Temperature: degrees Celsius (°C)
+ *  - Volume: litres (L)
+ *  - Flow: litres per hour (L/h)
+ *  - Specific heat capacity: kJ/(kg·K)
+ *  - Density: kg/L
+ *  - Power returned in kilowatts (kW)
+ *  - Energy returned/stored in kilowatt-hours (kWh)
+ */
+
+// Physical constants (water) used by the simple energy calculations.
+// Use temperature-dependent values for higher metering accuracy if required.
+#define cp 4.186f    // kJ/kg°C for water
+#define density 1.0f // kg/L for water
+
+class Power
+{
+public:
+    Power()
+    {
+        // Attempt to load persisted state from EEPROM
+        if (!loadFromEEPROM())
+        {
+            // No valid data, start from zero
+            max_power = 0.0f;
+            saveToEEPROM(true); // write magic
+        }
+    }
+
+    /**
+     * @brief Update power statistics based on current sensor readings.
+     * @param supply_temp Supply temperature in °C
+     * @param return_temp Return temperature in °C
+     * @param flow_lph Volumetric flow in litres per hour (L/h)
+     * @return Instantaneous thermal power in kilowatts (kW)
+     * @remarks Updates max_power if new value exceeds previous maximum.
+     */
+    float updatePower(float supply_temp, float return_temp, float flow_lph);
+
+    /**
+     * @brief Get the percentage of current power relative to the maximum power calibrated.
+     * @return Power as a percentage of max_power (0.0f to 100.0f)
+     * @remarks Returns 0 if max_power is zero.
+     */
+    float getPowerPercent();
+
+    /**
+     * @brief Set a new maximum power value.
+     * @param new_max_power New maximum power value (kWh)
+     * @return true if max_power updated, false if new_max_power is not greater than current
+     * @remarks Persists the new value to EEPROM if updated.
+     */
+    bool setMaxPower(float new_max_power);
+
+    /**
+     * @brief Get the maximum power calibrated.
+     * @return Maximum power (kWh)
+     */
+    float getMaxPower() const { return max_power; }
+
+    /**
+     * @brief Get the current power consumption.
+     * @return Current power (kWh)
+     */
+    float getPower() const { return power; }
+
+    /**
+     * @brief Check if EEPROM load was successful.
+     * @return true if EEPROM data was loaded correctly, false otherwise
+     * @remarks Returns false if last EEPROM load failed or data was invalid.
+     */
+    bool eepromLoadOk() const { return !eeprom_failure; }
+
+private:
+    /**
+     * @brief Magic number used to validate EEPROM data integrity.
+     * @note Change this value if EEPROM layout changes.
+     */
+    const uint16_t magic = 0x9449; // Magic number to validate EEPROM data
+
+    float power = 0.0f;          // Power consumed in last 24 hours (kWh)
+    float max_power = 0.0f;      // Max power consumed (kWh)
+    bool eeprom_failure = false; // True if last EEPROM load failed
+
+    enum EEPROM_Layout
+    {
+        EEPROM_MAGIC = 0,
+        EEPROM_MAX_POWER = 2,
+    };
+
+    /**
+     * @brief Load persisted power state from EEPROM into this instance
+     * @return true if valid data was loaded (magic matches), false otherwise
+     */
+    bool loadFromEEPROM();
+
+    /**
+     * @brief Persist current power state into EEPROM
+     * @return true on success
+     */
+    bool saveToEEPROM(bool update_magic = false);
+
+    /**
+     * @brief Compute instantaneous thermal power.
+     * @param supply_temp_degC Supply temperature in °C
+     * @param return_temp_degC Return temperature in °C
+     * @param flow_lph Volumetric flow in litres per hour (L/h)
+     * @return Thermal power in kilowatts (kW). Signed: positive means heat delivered when supply > return.
+     *
+     * Units:
+     * - cp: kJ/(kg·K)
+     * - density: kg/L
+     * - L/h -> kg/h -> kJ/h -> kJ/s -> kW (divide by 3600)
+     */
+    inline float getThermalPower(float supply_temp, float return_temp, float flow_lph)
+    {
+        const float seconds_per_hour = 3600.0f;
+
+        float delta_t = supply_temp - return_temp;
+
+        // optional deadband to avoid noise integration
+        const float DT_DEADBAND = 0.05f; // °C
+        if (fabs(delta_t) < DT_DEADBAND)
+            delta_t = 0.0f;
+
+        // return signed power (positive when supply > return)
+        return (flow_lph * density * cp * delta_t) / seconds_per_hour;
+    }
+};

--- a/firmware/include/power.h
+++ b/firmware/include/power.h
@@ -4,7 +4,7 @@
 #pragma once
 
 /**
- * @file energy.h
+ * @file power.h
  * @brief Energy calculation helpers and persistence for the TFM-100 firmware.
  * @author Salvo Musumeci
  * @note All functions use the following units unless otherwise stated:
@@ -87,8 +87,8 @@ private:
      */
     const uint16_t magic = 0x9449; // Magic number to validate EEPROM data
 
-    float power = 0.0f;          // Power consumed in last 24 hours (kWh)
-    float max_power = 0.0f;      // Max power consumed (kWh)
+    float power = 0.0f;          // Current/instantaneous power (kW)
+    float max_power = 0.0f;      // Maximum observed power (kW)
     bool eeprom_failure = false; // True if last EEPROM load failed
 
     enum EEPROM_Layout
@@ -109,30 +109,5 @@ private:
      */
     bool saveToEEPROM(bool update_magic = false);
 
-    /**
-     * @brief Compute instantaneous thermal power.
-     * @param supply_temp_degC Supply temperature in °C
-     * @param return_temp_degC Return temperature in °C
-     * @param flow_lph Volumetric flow in litres per hour (L/h)
-     * @return Thermal power in kilowatts (kW). Signed: positive means heat delivered when supply > return.
-     *
-     * Units:
-     * - cp: kJ/(kg·K)
-     * - density: kg/L
-     * - L/h -> kg/h -> kJ/h -> kJ/s -> kW (divide by 3600)
-     */
-    inline float getThermalPower(float supply_temp, float return_temp, float flow_lph)
-    {
-        const float seconds_per_hour = 3600.0f;
 
-        float delta_t = supply_temp - return_temp;
-
-        // optional deadband to avoid noise integration
-        const float DT_DEADBAND = 0.05f; // °C
-        if (fabs(delta_t) < DT_DEADBAND)
-            delta_t = 0.0f;
-
-        // return signed power (positive when supply > return)
-        return (flow_lph * density * cp * delta_t) / seconds_per_hour;
-    }
 };

--- a/firmware/src/can_messages.cpp
+++ b/firmware/src/can_messages.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <mcp_can.h>
 #include <flow.h>
+#include <energy.h>
 #include <cli.h>
 #include <scheduler.h>
 #include "can_messages.h"
@@ -49,6 +50,7 @@ extern PT100 return_sensor;
 extern CLIScreenManager cli;
 extern Scheduler scheduler;      // Deve essere definito nel main o scheduler
 extern NodeStatus_t node_status; // Convertito da NodeStatus_t
+extern Energy energyObj;
 
 uint8_t *HeartbeatMessage::buildPayload(uint8_t *len)
 {
@@ -163,5 +165,37 @@ uint8_t *CAN_Temperature::buildPayload(uint8_t *len)
   data[1] = (supply_temp >> 8) & 0xFF;
   data[2] = return_temp & 0xFF;
   data[3] = (return_temp >> 8) & 0xFF;
+  return data;
+};
+
+uint8_t *CAN_PowerAndEnergy::buildPayload(uint8_t *len)
+{
+  if (len == nullptr)
+  {
+    return nullptr;
+  }
+  /*
+   * Power and energy payload (8 bytes):
+   * - bytes 0..1: Energy in the last 24h in kWh (uint16_t, big-endian)
+   * - bytes 2..4: Energy total in kWh (uint24_t, big-endian)
+   * - bytes 5..6: Power in kW (uint16_t, big-endian)
+   * - byte 7: reserved for future use (set to 0)
+   */
+
+  *len = 8;
+  float actual_power = getThermalPower(supply_sensor.average_temperature, return_sensor.average_temperature, flowObj.getFlow());
+  uint32_t energy_total = max(0, int(energyObj.getEnergyTotal()));
+  uint16_t energy_24h = max(0, int(energyObj.getEnergy24h() * 100));
+  uint16_t power = max(0, int(actual_power * 10));
+
+  uint8_t *data = new uint8_t[8];
+  data[0] = energy_24h & 0xFF;
+  data[1] = (energy_24h >> 8) & 0xFF;
+  data[2] = (energy_total) & 0xFF;
+  data[3] = (energy_total >> 8) & 0xFF;
+  data[4] = (energy_total >> 16) & 0xFF;
+  data[5] = power & 0xFF;
+  data[6] = (power >> 8) & 0xFF;
+  data[7] = 0; // reserved for future use
   return data;
 };

--- a/firmware/src/can_messages.cpp
+++ b/firmware/src/can_messages.cpp
@@ -175,10 +175,10 @@ uint8_t *CAN_PowerAndEnergy::buildPayload(uint8_t *len)
     return nullptr;
   }
   /*
-   * Power and energy payload (8 bytes):
-   * - bytes 0..1: Energy in the last 24h in kWh (uint16_t, big-endian)
-   * - bytes 2..4: Energy total in kWh (uint24_t, big-endian)
-   * - bytes 5..6: Power in kW (uint16_t, big-endian)
+   * Power and energy payload (8 bytes, little-endian):
+   * - bytes 0..1: Energy in the last 24h (uint16_t, 0.01 kWh per LSB)
+   * - bytes 2..4: Energy total in kWh (uint24_t, 1 kWh per LSB)
+   * - bytes 5..6: Power in kW (uint16_t, 0.1 kW per LSB)
    * - byte 7: reserved for future use (set to 0)
    */
 

--- a/firmware/src/can_messages.cpp
+++ b/firmware/src/can_messages.cpp
@@ -184,9 +184,32 @@ uint8_t *CAN_PowerAndEnergy::buildPayload(uint8_t *len)
 
   *len = 8;
   float actual_power = getThermalPower(supply_sensor.average_temperature, return_sensor.average_temperature, flowObj.getFlow());
-  uint32_t energy_total = max(0, int(energyObj.getEnergyTotal()));
-  uint16_t energy_24h = max(0, int(energyObj.getEnergy24h() * 100));
-  uint16_t power = max(0, int(actual_power * 10));
+  uint32_t energy_total = (uint32_t)max(0.0f, min(energyObj.getEnergyTotal(), 16777215.0f));
+
+  // Encode 24h energy as centi-kWh in uint16_t, with clamping to avoid overflow.
+  float energy24h = energyObj.getEnergy24h();
+  if (energy24h < 0.0f)
+  {
+    energy24h = 0.0f;
+  }
+  // Maximum encodable value with scale factor 100 is 655.35 kWh
+  if (energy24h > 655.35f)
+  {
+    energy24h = 655.35f;
+  }
+  uint16_t energy_24h = (uint16_t)roundf(energy24h * 100.0f);
+  // Scale power to deci-kW, then round and clamp to uint16_t range to avoid overflow.
+  float power_scaled = actual_power * 10.0f;
+  if (power_scaled < 0.0f)
+  {
+    power_scaled = 0.0f;
+  }
+  uint32_t power_u = (uint32_t)roundf(power_scaled);
+  if (power_u > 0xFFFFu)
+  {
+    power_u = 0xFFFFu;
+  }
+  uint16_t power = (uint16_t)power_u;
 
   uint8_t *data = new uint8_t[8];
   data[0] = energy_24h & 0xFF;

--- a/firmware/src/cli.cpp
+++ b/firmware/src/cli.cpp
@@ -8,6 +8,8 @@
 #include <MAX31865_NonBlocking.h>
 #include <diagnostics.h>
 #include <utils.h>
+#include <energy.h>
+#include <power.h>
 
 // External variables
 extern PT100 supply_sensor; // main.cpp
@@ -17,6 +19,8 @@ extern Scheduler scheduler; // main.cpp
 extern uint8_t node_id;     // main.cpp
 extern MCP_CAN CAN0;        // main.cpp
 extern Diagnostics DSM;     // main.cpp
+extern Energy energyObj;    // main.cpp
+extern Power powerObj;      // main.cpp
 
 // Constructor
 CLIScreenManager::CLIScreenManager(Stream *stream, uint16_t width, uint16_t height)
@@ -284,18 +288,17 @@ void CLIScreenManager::drawRealTimeSignals(bool full_update)
     ansi->normal();
     ansi->bold();
     ansi->gotoXY(18, 9);
-    ftostr(buf, power, 1);
+    ftostr(buf, powerObj.getPower(), 1);
     ansi->print(buf);
     ansi->print(" kW   ");
-    printProgressBar((uint8_t)power_percentage, 30);
-    ansi->print("  ");
+    printProgressBar((uint8_t)powerObj.getPowerPercent(), 30);
     ansi->normal();
     ansi->gotoXY(27, 13);
-    ftostr(buf, energy_24h, 2);
+    ftostr(buf, energyObj.getEnergy24h(), 2);
     ansi->print(buf);
     ansi->print(" kWh   ");
     ansi->gotoXY(17, 14);
-    ftostr(buf, energy_total / 1000.0, 2);
+    ftostr(buf, energyObj.getEnergyTotal() / 1000.0, 2);
     ansi->print(buf);
     ansi->print(" MWh   ");
     ansi->gotoXY(9, 16);
@@ -683,7 +686,7 @@ void CLIScreenManager::printProgressBar(uint8_t progress, uint8_t width, const _
     ansi->normal();
     ansi->print("] ");
     ansi->print(progress);
-    ansi->println("%");
+    ansi->println("%   ");
 }
 
 /**

--- a/firmware/src/diag_comm.cpp
+++ b/firmware/src/diag_comm.cpp
@@ -6,6 +6,7 @@ extern TFM100_DTC_Dict dtc_dict_instance; // DTC dictionary instance (defined in
 
 // Static member definitions
 SerialProtocol DiagComm::comm;
+uint32_t DiagComm::last_diag_update = 0;
 DiagComm *DiagComm::s_instance = nullptr;
 
 void DiagComm::process(uint32_t td)
@@ -27,14 +28,22 @@ void DiagComm::process(uint32_t td)
         clientConnected = false;
         // Client just disconnected
     }
-    // Read from Serial and feed protocol (non-blocking)
-    while (Serial.available() > 0)
+    else if (clientConnected)
     {
-        int c = Serial.read();
-        if (c >= 0)
+        if (td - last_diag_update >= 1000) // 1s interval for periodic updates
         {
-            uint8_t ch = (uint8_t)c;
-            comm.feed(&ch, 1);
+            last_diag_update = td;
+            periodically_update();
+        }
+        // Read from Serial and feed protocol (non-blocking)
+        while (Serial.available() > 0)
+        {
+            int c = Serial.read();
+            if (c >= 0)
+            {
+                uint8_t ch = (uint8_t)c;
+                comm.feed(&ch, 1);
+            }
         }
     }
 }

--- a/firmware/src/diag_comm.cpp
+++ b/firmware/src/diag_comm.cpp
@@ -41,13 +41,19 @@ void DiagComm::process(uint32_t td)
 
 void DiagComm::periodically_update()
 {
+    float power = getThermalPower(supply_sensor.average_temperature, return_sensor.average_temperature, flowObj.getFlow());
+
+    char powerStr[16];
+    dtostrf(power*1000, 6, 3, powerStr); // width=6, precision=3
+    comm.send_log(SerialProtocol::LOG_INFO, powerStr);
+
     comm.send_param("ST", supply_sensor.average_temperature, 1);
     comm.send_param("RT", return_sensor.average_temperature, 1);
     comm.send_param("WF", flowObj.getFlow(), 1);
-    comm.send_param("E24", 0.0f, 1);
-    comm.send_param("ET", 0.0f, 1);
     comm.send_param("P%", 0.0f, 1);
-    comm.send_param("PWR", 0.0f, 1);
+    comm.send_param("E24", energyObj.getEnergy24h(), 1);
+    comm.send_param("ET", energyObj.getEnergyTotal(), 1);
+    comm.send_param("PWR", power, 1);
     comm.send_param("NS", (uint32_t)node_status);
 }
 

--- a/firmware/src/energy.cpp
+++ b/firmware/src/energy.cpp
@@ -1,0 +1,56 @@
+#include "Arduino.h"
+#include "EEPROM.h"
+#include "energy.h"
+
+/**
+ * @brief Load persisted energy state from EEPROM into this instance
+ * @return true if valid data was loaded (magic matches), false otherwise
+ */
+bool Energy::loadFromEEPROM()
+{
+    uint16_t stored_magic = 0;
+    EEPROM.get(ENERGY_EEPROM_OFFSET + EEPROM_MAGIC, stored_magic);
+    if (stored_magic != magic)
+    {
+        eeprom_failure = true;
+        return false;
+    }
+
+    EEPROM.get(ENERGY_EEPROM_OFFSET + EEPROM_ENERGY_TOTAL, energy_total);
+    EEPROM.get(ENERGY_EEPROM_OFFSET + EEPROM_ENERGY_24H, energy_24h);
+    return true;
+}
+
+/**
+ * @brief Persist current energy state into EEPROM
+ * @return true on success
+ */
+bool Energy::saveToEEPROM(bool update_magic)
+{
+    // Write magic first
+    if (update_magic)
+        EEPROM.put(ENERGY_EEPROM_OFFSET + EEPROM_MAGIC, magic);
+    EEPROM.put(ENERGY_EEPROM_OFFSET + EEPROM_ENERGY_TOTAL, energy_total);
+    EEPROM.put(ENERGY_EEPROM_OFFSET + EEPROM_ENERGY_24H, energy_24h);
+    // Optionally write last update timestamp
+    return true;
+}
+
+/**
+ * @brief Increase stored energy counters using measured volume.
+ * @param supply_temp Supply temperature in °C
+ * @param return_temp Return temperature in °C
+ * @param volume_liters Volume passed since last sample in litres
+ */
+void Energy::increase_energy(float supply_temp, float return_temp, float volume_liters)
+{
+    // Compute energy increment in kWh using simple formula
+    float dE = energyFromVolume_kWh(supply_temp, return_temp, volume_liters);
+
+    // Update totals. Signed dE allows positive (heating) and negative (cooling)
+    energy_total += dE;
+    energy_24h += dE;
+
+    // Persist
+    saveToEEPROM();
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -82,6 +82,18 @@ bool CANbusOff = false;
 bool CANbusWarn = false;
 bool HwFailure = true; // Assume HW failure until all init done
 
+// CAN RX interrupt flag
+volatile bool canRxPending = false;
+
+/**
+ * @brief Interrupt Service Routine for MCP2515 RX interrupt
+ * @remarks Called when MCP2515 receives a message. Sets flag for main loop processing.
+ */
+void canRxInterruptHandler()
+{
+  canRxPending = true;
+}
+
 // serial writer provided below as a free function
 
 
@@ -113,6 +125,66 @@ static void j1939_on_error(const J1939Descriptor &desc)
 
 void update_errors();
 
+/**
+ * @brief Process received CAN messages
+ * @remarks Handles energy reset commands via J1939 Proprietary A message (PGN 0xF183, SA 0x00).
+ * Interrupt-driven: only called when canRxPending flag is set by MCP2515 RX interrupt.
+ *
+ * J1939 Proprietary A Message format:
+ * - Priority: 6 (medium)
+ * - PGN: 0xF183 (Proprietary A range)
+ * - Source Address (SA): 0x00
+ * - Combined CAN ID: 0x18F18300
+ * - Payload (1-based byte numbering):
+ *   - Byte 1: Target node address (0xFF = all nodes, or specific node ID)
+ *   - Byte 2: Reset command type
+ *     - 0x01: Reset 24h energy counter only
+ *     - 0xFF: Reset both 24h and total energy counters
+ *   - Bytes 3-8: Reserved
+ */
+void processReceivedCanMessages()
+{
+  INT8U len = 0;
+  INT8U buf[8] = {0};
+  INT32U canId = 0;
+  INT8U ext = 0;
+
+  // Process all available CAN messages
+  while (CAN0.checkReceive() == CAN_MSGAVAIL)
+  {
+    // Read the message
+    CAN0.readMsgBuf(&canId, &ext, &len, buf);
+
+    // Check for energy reset command (J1939 Proprietary A PGN 0xF183, SA 0x00, Priority 6)
+    // Only process extended frames
+    if (ext == 1 && canId == 0x18F18300)
+    {
+      INT8U target_node = buf[0]; // Byte 1 (1-based)
+      INT8U command = buf[1];     // Byte 2 (1-based)
+
+      // Check if message is for this node (0xFF = broadcast to all nodes)
+      if (target_node == 0xFF || target_node == node_id)
+      {
+        // 0x01: Reset 24h energy counter only
+        if (command == 0x01)
+        {
+          energyObj.reset24h();
+          diagComm.send_info("Energy 24h reset");
+        }
+        // 0xFF: Reset both 24h and total energy counters
+        else if (command == 0xFF)
+        {
+          energyObj.resetAll();
+          diagComm.send_info("Energy 24h and total reset");
+        }
+      }
+    }
+  }
+
+  // Clear the interrupt flag after processing all messages
+  canRxPending = false;
+}
+
 void setup()
 {
   /**
@@ -143,6 +215,20 @@ void setup()
   if ((mcp_init = (CAN0.begin(MCP_ANY, CAN_250KBPS, MCP_8MHZ) == CAN_OK)))
     if ((mcp_normal = (CAN0.setMode(MCP_NORMAL) == MCP2515_OK)))
     {
+      // Configure CAN filters to accept only J1939 Proprietary A energy reset command
+      // Message: PGN 0xF183, SA 0x00, Priority 6 → CAN ID 0x18F18300
+      // RXB0: Mask 0 matches all 29 bits, Filter 0 accepts only this message
+      CAN0.init_Mask(0, 1, 0x1FFFFFFF);
+      CAN0.init_Filt(0, 1, 0x18F18300);
+
+      // RXB1: Mask 1 matches all bits but filters reject all messages (disable RXB1)
+      CAN0.init_Mask(1, 1, 0x1FFFFFFF);
+      CAN0.init_Filt(2, 1, 0x000); // Impossible to match
+
+      // Configure INT pin as input with pull-up and attach interrupt handler
+      // MCP2515 will pull INT low when a message is received
+      pinMode(MCP_INT, INPUT_PULLUP);
+      attachInterrupt(digitalPinToInterrupt(MCP_INT), canRxInterruptHandler, FALLING);
 
       // Monitor CAN controller error flags frequently (100ms)
       scheduler.addTask([](uint32_t td)
@@ -264,6 +350,10 @@ void loop()
   // Let J1939 manager process pending transmissions/timeouts
   if (j1939)
     j1939->process(millis());
+
+  // Process received CAN messages only if interrupt flag is set (e.g., energy reset commands)
+  if (canRxPending)
+    processReceivedCanMessages();
 
   // Advance non-blocking sensor state machines
   supply_sensor.process();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -36,8 +36,9 @@
 #include <McpCanAdapter.h>
 #include <dip_switch.h>
 #include <dtc.h>
-#include <EEPROM.h>
 #include <utils.h>
+#include <energy.h>
+#include <power.h>
 #include <diag_comm.h>
 
 /* CLI */
@@ -48,6 +49,8 @@ PT100 return_sensor = PT100(RETURN_CS);
 
 /* Flow Sensor Variables */
 Flow flowObj = Flow(FLOW_TICKS_PER_LITER);
+Energy energyObj = Energy();
+Power powerObj = Power();
 
 /* Set-up J1939 Transport Layer */
 // Allocation of CAN controller and adapter
@@ -159,6 +162,7 @@ void setup()
 
   // If diagnostics EEPROM load failed during Diagnostics construction, flag the DTC
   DSM.setRaw(DTC_DSMEepromFailure, !DSM.eepromLoadOk());
+  DSM.setRaw(DTC_PowerEepromFailure, !powerObj.eepromLoadOk());
 
   // Compute node address from DIP switches (base + switch value)
   node_id = dip_switch_read() | NODE_ID_BASE;
@@ -212,10 +216,18 @@ void setup()
   j1939 = new J1939Manager(canAdapter, j1939_cbs);
   j1939->begin(node_id);
 
-  // Initialize flow sensor (callback currently a stub)
-  flowObj.begin([](float flow) {});
+  // // Initialize flow sensor (callback currently a stub)
+  flowObj.begin([](float flow)
+                {
+                // Increase energy counters based on last measured temperatures
+                energyObj.increase_energy(supply_sensor.last_temperature,
+                                          return_sensor.last_temperature,
+                                          1.0f / FLOW_TICKS_PER_LITER);
+                powerObj.updatePower(supply_sensor.last_temperature,
+                                      return_sensor.last_temperature,
+                                      flow); });
 
-  // Add message objects to J1939 manager
+  // // Add message objects to J1939 manager
   j1939->registerMessage(&HBMessage);
   j1939->registerMessage(&TempMessage);
   j1939->registerMessage(&TempAndFlowMessage);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -95,34 +95,6 @@ J1939_DM1Message DM1 = J1939_DM1Message(1000); // 1s interval
 TFM100_DTC_Dict dtc_dict_instance = TFM100_DTC_Dict();
 Diagnostics DSM = Diagnostics(&dtc_dict_instance);
 
-// -----------------------------------------------------------------------------
-// Persistence hooks (default application implementation using AVR EEPROM)
-// These implement the required low-level write/read of raw bytes at a
-// logical offset. The library composes logical offsets starting at 0 for
-// diagnostics; we map them to physical EEPROM addresses by adding
-// DIAGNOSTICS_EEPROM_OFFSET.
-// -----------------------------------------------------------------------------
-void diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length)
-{
-  uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
-  for (uint8_t i = 0; i < length; i++)
-  {
-    uint8_t v = data[i];
-    // EEPROM.update writes only if value differs, minimizing wear
-    EEPROM.update(phys + i, v);
-  }
-}
-
-bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length)
-{
-  uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
-  for (uint8_t i = 0; i < length; i++)
-  {
-    data[i] = EEPROM.read(phys + i);
-  }
-  return true; // read always succeeds (caller is responsible for magic validation)
-}
-
 // Forward declaration of J1939Descriptor is available via J1939Manager.h
 // Provide a simple error callback to forward J1939 manager errors to CLI
 static void j1939_on_error(const J1939Descriptor &desc)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -101,6 +101,7 @@ void canRxInterruptHandler()
 HeartbeatMessage HBMessage = HeartbeatMessage(5000); // 5s interval
 CAN_Temperature TempMessage = CAN_Temperature();
 CAN_FilteredTemperatureAndFlow TempAndFlowMessage = CAN_FilteredTemperatureAndFlow();
+CAN_PowerAndEnergy PowerAndEnergyMessage = CAN_PowerAndEnergy();
 J1939_DM1Message DM1 = J1939_DM1Message(1000); // 1s interval
 
 /* Diagnostics */
@@ -289,6 +290,7 @@ void setup()
   j1939->registerMessage(&HBMessage);
   j1939->registerMessage(&TempMessage);
   j1939->registerMessage(&TempAndFlowMessage);
+  j1939->registerMessage(&PowerAndEnergyMessage);
   j1939->registerMessage(&DM1);
 
   // Schedule periodic PT100 measurements (driver triggers non-blocking measurement)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -208,6 +208,7 @@ void setup()
   // If diagnostics EEPROM load failed during Diagnostics construction, flag the DTC
   DSM.setRaw(DTC_DSMEepromFailure, !DSM.eepromLoadOk());
   DSM.setRaw(DTC_PowerEepromFailure, !powerObj.eepromLoadOk());
+  DSM.setRaw(DTC_EnergyEepromFailure, !energyObj.eepromLoadOk());
 
   // Compute node address from DIP switches (base + switch value)
   node_id = dip_switch_read() | NODE_ID_BASE;

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -1,0 +1,57 @@
+#include "power.h"
+#include "EEPROM.h"
+
+float Power::updatePower(float supply_temp, float return_temp, float flow_lph)
+{
+    power = getThermalPower(supply_temp, return_temp, flow_lph);
+    if (power < 0.0f)
+        return 0.0f;
+    return power;
+}
+
+float Power::getPowerPercent()
+{
+    if (max_power == 0.0f)
+        return 0.0f;
+    return (power / max_power) * 100.0f;
+}
+
+/**
+ * @brief Load persisted energy state from EEPROM into this instance
+ * @return true if valid data was loaded (magic matches), false otherwise
+ */
+bool Power::loadFromEEPROM()
+{
+    uint16_t stored_magic = 0;
+    EEPROM.get(POWER_EEPROM_OFFSET + EEPROM_MAGIC, stored_magic);
+    if (stored_magic != magic)
+    {
+        eeprom_failure = true;
+        return false;
+    }
+
+    EEPROM.get(POWER_EEPROM_OFFSET + EEPROM_MAX_POWER, max_power);
+    return true;
+}
+
+/**
+ * @brief Persist current energy state into EEPROM
+ * @return true on success
+ */
+bool Power::saveToEEPROM(bool update_magic)
+{
+    // Write magic first
+    if (update_magic)
+        EEPROM.put(POWER_EEPROM_OFFSET + EEPROM_MAGIC, magic);
+    EEPROM.put(POWER_EEPROM_OFFSET + EEPROM_MAX_POWER, max_power);
+    return true;
+}
+
+bool Power::setMaxPower(float new_max_power)
+{
+    if (new_max_power <= 0.0f)
+        return false;
+
+    max_power = new_max_power;
+    return saveToEEPROM();
+}

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -6,6 +6,12 @@ float Power::updatePower(float supply_temp, float return_temp, float flow_lph)
     power = getThermalPower(supply_temp, return_temp, flow_lph);
     if (power < 0.0f)
         return 0.0f;
+
+    if (power > max_power)
+    {
+        max_power = power;
+        saveToEEPROM();
+    }
     return power;
 }
 
@@ -35,7 +41,7 @@ bool Power::loadFromEEPROM()
 }
 
 /**
- * @brief Persist current energy state into EEPROM
+ * @brief Persist current power state into EEPROM
  * @return true on success
  */
 bool Power::saveToEEPROM(bool update_magic)

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -1,4 +1,5 @@
 #include "power.h"
+#include "energy.h"
 #include "EEPROM.h"
 
 float Power::updatePower(float supply_temp, float return_temp, float flow_lph)

--- a/firmware/src/utils.cpp
+++ b/firmware/src/utils.cpp
@@ -1,0 +1,31 @@
+
+#include <stdint.h>
+#include <config.h>
+#include <EEPROM.h>
+// -----------------------------------------------------------------------------
+// Persistence hooks (default application implementation using AVR EEPROM)
+// These implement the required low-level write/read of raw bytes at a
+// logical offset. The library composes logical offsets starting at 0 for
+// diagnostics; we map them to physical EEPROM addresses by adding
+// DIAGNOSTICS_EEPROM_OFFSET.
+// -----------------------------------------------------------------------------
+void diag_save_to_persistent(uint16_t offset, const uint8_t *data, uint8_t length)
+{
+    uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
+    for (uint8_t i = 0; i < length; i++)
+    {
+        uint8_t v = data[i];
+        // EEPROM.update writes only if value differs, minimizing wear
+        EEPROM.update(phys + i, v);
+    }
+}
+
+bool diag_load_from_persistent(uint16_t offset, uint8_t *data, uint8_t length)
+{
+    uint16_t phys = (uint16_t)(DIAGNOSTICS_EEPROM_OFFSET + offset);
+    for (uint8_t i = 0; i < length; i++)
+    {
+        data[i] = EEPROM.read(phys + i);
+    }
+    return true; // read always succeeds (caller is responsible for magic validation)
+}


### PR DESCRIPTION
This pull request introduces a comprehensive refactor and enhancement of the power and energy tracking subsystem in the firmware. It adds new classes for energy and power calculation and persistence, integrates these into diagnostics, CAN messaging, and CLI display, and updates the DTC system to handle EEPROM failures for energy and power. The changes improve modularity, reliability, and visibility of power and energy statistics across the system.

**Subsystem additions and integration**

* Added new `Energy` and `Power` classes for calculation, persistence, and statistics, including methods for EEPROM load/save, calculation helpers, and state management. (`firmware/include/energy.h`, `firmware/include/power.h`, `firmware/src/energy.cpp`, [[1]](diffhunk://#diff-9e8989928b611223b78dc6b953b5dd287fe1e28ebd7bde4aed7aae4b40526d00R1-R138) [[2]](diffhunk://#diff-01541a8dd3173292413a380ebbf72f5d7dfc0f37d91f6f55d8a5a1b5dad20578R1-R141) [[3]](diffhunk://#diff-67b1c668cc963889f3058f0df465d776129fac49252e05f1263ae8f05897375cR1-R56)
* Integrated `energyObj` and `powerObj` instances throughout the firmware, including CLI, CAN messages, diagnostics, and main initialization. (`firmware/src/main.cpp`, `firmware/include/diag_comm.h`, `firmware/src/cli.cpp`, `firmware/src/can_messages.cpp`, [[1]](diffhunk://#diff-8b877285b1287e2c225a5db5aef0e2b6a599a550b84885b7532764ad56c84d43L39-R41) [[2]](diffhunk://#diff-8b877285b1287e2c225a5db5aef0e2b6a599a550b84885b7532764ad56c84d43R52-R53) [[3]](diffhunk://#diff-635ad5bc401cb8dab4c45ae5e46e63f06bc8884af644bfbf926690ea75481251R11-R17) [[4]](diffhunk://#diff-a26ee133ffdbca25f470c6000446450e232b36e34f68d739d0e575c1730a9a57R53) [[5]](diffhunk://#diff-a43351f2aea22a360fb4bf7e06c206fcdb4319fb8a006f74d7008e054e7dfcaeR11-R12) [[6]](diffhunk://#diff-a43351f2aea22a360fb4bf7e06c206fcdb4319fb8a006f74d7008e054e7dfcaeR22-R23)

**CAN messaging and diagnostics**

* Added new CAN payload for power and energy statistics, including encoding of 24h energy, total energy, and instantaneous power. (`firmware/include/can_messages.h`, `firmware/src/can_messages.cpp`, [[1]](diffhunk://#diff-1219446de0ae238c56f19e56b16c0befb7ba644d6d1c3754a3034a49af886135R20) [[2]](diffhunk://#diff-a26ee133ffdbca25f470c6000446450e232b36e34f68d739d0e575c1730a9a57R170-R201)
* Updated diagnostics communication to periodically report power and energy values, and added a periodic update mechanism. (`firmware/include/diag_comm.h`, `firmware/src/diag_comm.cpp`, [[1]](diffhunk://#diff-635ad5bc401cb8dab4c45ae5e46e63f06bc8884af644bfbf926690ea75481251R71) [[2]](diffhunk://#diff-79d88875d61717ce09b78ce6e0c8972d96266fc8af3e7c8c23c19b00b1d751f3R9) [[3]](diffhunk://#diff-79d88875d61717ce09b78ce6e0c8972d96266fc8af3e7c8c23c19b00b1d751f3R31-R37) [[4]](diffhunk://#diff-79d88875d61717ce09b78ce6e0c8972d96266fc8af3e7c8c23c19b00b1d751f3R49-R65)

**CLI and display**

* Refactored CLI display logic to use new `Energy` and `Power` classes for real-time signal display, replacing legacy variables and improving accuracy. (`firmware/include/cli.h`, `firmware/src/cli.cpp`, [[1]](diffhunk://#diff-233e1224b654e430d6d352a31ee3a4eaf1c9f77fe9a13228c574c1ceb23376b7L37-L39) [[2]](diffhunk://#diff-a43351f2aea22a360fb4bf7e06c206fcdb4319fb8a006f74d7008e054e7dfcaeL287-R301)

**EEPROM and configuration**

* Defined new EEPROM offsets for power and energy storage, and implemented robust load/save logic with magic number validation. (`firmware/include/config.h`, [firmware/include/config.hR37-R38](diffhunk://#diff-f1699d3524134b511fb825ae079ad6199608a57b80b4fb01562a655834f149b3R37-R38))

**DTC (Diagnostic Trouble Codes) enhancements**

* Added new DTC codes and dictionary entries for energy and power EEPROM failures to improve error reporting and reliability. (`firmware/include/dtc.h`, [[1]](diffhunk://#diff-dbeda68eb199141814924ea5754f7bf9e3302bbfeca85eed73cac7acac1f118aR29-R30) [[2]](diffhunk://#diff-dbeda68eb199141814924ea5754f7bf9e3302bbfeca85eed73cac7acac1f118aR63-R64) [[3]](diffhunk://#diff-dbeda68eb199141814924ea5754f7bf9e3302bbfeca85eed73cac7acac1f118aR90-R92)