### PR TITLE
Feature/prj optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ dkms.conf
 
 # Bootloader hex files
 !bootloader/*.hex
+
+#Webui build
+webui/node_modules
+webui/.vite

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+platformio_override.ini

--- a/firmware/include/config.h
+++ b/firmware/include/config.h
@@ -50,6 +50,8 @@
 #define POWER_EEPROM_SIZE   6   // 2 bytes magic + 4 bytes max_power
 #define ENERGY_EEPROM_SIZE 10   // 2 bytes magic + 4 bytes energy_total + 4 bytes energy_24h
 
+#define ENERGY_EEPROM_SAVE_INTERVAL_MS 60000UL // Persist energy to EEPROM at most once per minute
+
 // Compile-time checks to ensure EEPROM regions do not overlap.
 static_assert(POWER_EEPROM_OFFSET + POWER_EEPROM_SIZE <= ENERGY_EEPROM_OFFSET,
               "EEPROM layout error: POWER region overlaps ENERGY region");

--- a/firmware/include/energy.h
+++ b/firmware/include/energy.h
@@ -94,6 +94,14 @@ public:
     float getEnergyTotal() { return energy_total; }
 
     /**
+     * @brief Persist energy to EEPROM if dirty and the minimum interval has elapsed.
+     * @param now_ms Current millis() timestamp
+     * @remarks Call periodically (e.g., every scheduler tick) to bound EEPROM write rate.
+     *          Writes at most once every ENERGY_EEPROM_SAVE_INTERVAL_MS milliseconds.
+     */
+    void persistIfDue(uint32_t now_ms);
+
+    /**
      * @brief Check if EEPROM load was successful.
      * @return true if EEPROM data was loaded correctly, false otherwise
      * @remarks Returns false if last EEPROM load failed or data was invalid.
@@ -123,6 +131,8 @@ private:
     float energy_24h = 0.0f;     // Energy consumed in last 24 hours (kWh)
     float energy_total = 0.0f;   // Total energy consumed (kWh)
     bool eeprom_failure = false; // True if last EEPROM load failed
+    bool eeprom_dirty = false;   // True if in-RAM values differ from last EEPROM save
+    uint32_t last_eeprom_save_ms = 0; // millis() at last EEPROM persist
 
     enum EEPROM_Layout
     {

--- a/firmware/include/power.h
+++ b/firmware/include/power.h
@@ -23,8 +23,8 @@ public:
         // Attempt to load persisted state from EEPROM
         if (!loadFromEEPROM())
         {
-            // No valid data, start from zero
-            max_power = 0.0f;
+            // No valid data, start from default maximum power
+            max_power = 24.0f;
             saveToEEPROM(true); // write magic
         }
     }
@@ -48,7 +48,7 @@ public:
 
     /**
      * @brief Set a new maximum power value.
-     * @param new_max_power New maximum power value (kWh)
+     * @param new_max_power New maximum power value (kW)
      * @return true if max_power updated, false if new_max_power is not greater than current
      * @remarks Persists the new value to EEPROM if updated.
      */
@@ -56,13 +56,13 @@ public:
 
     /**
      * @brief Get the maximum power calibrated.
-     * @return Maximum power (kWh)
+     * @return Maximum power (kW)
      */
     float getMaxPower() const { return max_power; }
 
     /**
      * @brief Get the current power consumption.
-     * @return Current power (kWh)
+     * @return Current power (kW)
      */
     float getPower() const { return power; }
 
@@ -78,7 +78,7 @@ private:
      * @brief Magic number used to validate EEPROM data integrity.
      * @note Change this value if EEPROM layout changes.
      */
-    const uint16_t magic = 0x9449; // Magic number to validate EEPROM data
+    const uint16_t magic = 0x944A; // Magic number to validate EEPROM data
 
     float power = 0.0f;          // Current/instantaneous power (kW)
     float max_power = 0.0f;      // Maximum observed power (kW)

--- a/firmware/lib/J1939/J1939Manager.cpp
+++ b/firmware/lib/J1939/J1939Manager.cpp
@@ -407,9 +407,6 @@ void J1939Manager::processRegisteredMessages(uint16_t now_ms)
             if (data != nullptr && len > 0)
             {
                 bool ok = sendCopy(msg->getPGN(), data, len, msg->getDestination(), msg->getPriority());
-                // Reclaim the payload buffer now that it has been copied into the pool.
-                delete[] data;
-                data = nullptr;
                 if (!ok)
                     last_error_ = J1939TxError::POOL_NO_SPACE;
             }

--- a/firmware/lib/J1939/J1939_DM.cpp
+++ b/firmware/lib/J1939/J1939_DM.cpp
@@ -24,7 +24,7 @@ uint8_t *J1939_DM1Message::buildPayload(uint8_t *len)
 {
     uint8_t numberOfErrors = J1939_DM::getNumberOfActiveErrors();
     *len = 2 + numberOfErrors * 4;
-    uint8_t *payload = new uint8_t[*len];
+    static uint8_t payload[DIAGNOSTICS_MEMORY_SIZE * 4 + 2]; // max size: 2 bytes for lamp status + 4 bytes per DTC
     if (!payload)
     {
         *len = 0;

--- a/firmware/lib/PT100/PT100.cpp
+++ b/firmware/lib/PT100/PT100.cpp
@@ -2,12 +2,15 @@
 
 // Constructor for the PT100 class.
 // Initializes the sensor object.
-PT100::PT100(int csPin) : sensor(csPin), measurementRunning(false), errorDetected(false), last_temperature(0.0), last_fault(0)
+PT100::PT100(int csPin) : measurementRunning(false),
+                          alpha(1.0f),
+                          filterInitialized(false),
+                          sensor(csPin),
+                          errorDetected(false),
+                          last_temperature(0.0),
+                          average_temperature(0.0f),
+                          last_fault(0)
 {
-    // Constructor implementation
-    filterInitialized = false;
-    alpha = 1;
-    average_temperature = 0;
 }
 
 bool PT100::begin()

--- a/firmware/lib/flow/flow.cpp
+++ b/firmware/lib/flow/flow.cpp
@@ -18,9 +18,12 @@ void flow_ISR()
 {
     // Handle the state transitions for the capture process based on the current step.
     uint16_t tick = TCNT1;
-    uint16_t delta_tick = tick - last_tick;
-    if (delta_tick < 0)
-        delta_tick += UINT16_MAX;
+    uint16_t delta_tick;
+    
+    if (tick >= last_tick)
+        delta_tick = tick - last_tick;
+    else
+        delta_tick = (UINT16_MAX + 1 - last_tick) + tick; // Handle overflow
     if (delta_tick < (uint16_t)DEBOUNCE_TICK)
         return; // Debounce
     last_tick = tick;

--- a/firmware/lib/scheduler/scheduler.cpp
+++ b/firmware/lib/scheduler/scheduler.cpp
@@ -17,10 +17,13 @@ uint8_t Scheduler::addTask(void (*taskFunc)(uint32_t), uint32_t period)
 void Scheduler::run()
 {
     uint32_t currentTime = millis();
-    uint32_t delta = currentTime - last_millis;
-    if (delta < 0)
+    uint32_t delta;
+    if (currentTime >= last_millis)
     {
-        systemTime += (0xFFFFFFFF - last_millis);
+        delta = currentTime - last_millis;
+    } else {
+        // Handle millis() overflow
+        delta = (UINT32_MAX - last_millis) + currentTime + 1;
     }
     systemTime += delta;
     last_millis = currentTime;

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -41,4 +41,3 @@ build_flags =
   -Wl,-Map=.pio/build/TFM_100/firmware.map  ; generate the .map file with symbols and sizes
 
 monitor_speed=115200
-upload_port=COM17

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs=TFM_100
+extra_configs = platformio_override.ini
 
 [env:TFM_100]
 platform = atmelavr
@@ -25,20 +26,19 @@ lib_deps=
   robtillaart/ANSI
   https://github.com/budulinek/MAX31865_NonBlocking.git
 
-upload_port=COM17
-monitor_port=COM17
 build_flags =
   -I include
   -D J1939_PAYLOAD_POOL_SIZE=100
   -D J1939_MAX_REGISTERED_MESSAGES=10
   -D J1939_MESSAGE_QUEUE=10
   -D DIAGNOSTICS_MEMORY_SIZE=10
-  -Os                            ; ottimizza per ridurre la dimensione del codice
-  -flto                          ; abilita Link Time Optimization (più riduzione codice)
-  -ffunction-sections            ; mette ogni funzione in una sezione separata
-  -fdata-sections                ; mette ogni variabile/dato in una sezione separata
-  -Wl,--gc-sections              ; linker: elimina funzioni/dati non usati
-  -lprintf_min                   ; forza printf minimale (senza float) per ridurre la flash
-  -Wl,-Map=.pio/build/TFM_100/firmware.map  ; genera il file .map con simboli e dimensioni
+  -Os                            ; reduce code size
+  -flto                          ; enable Link Time Optimization (further code size reduction)
+  -ffunction-sections            ; place each function in a separate section
+  -fdata-sections                ; place each variable/data in a separate section
+  -Wl,--gc-sections              ; linker: remove unused functions/data
+  -lprintf_min                   ; force minimal printf (without float) to reduce flash
+  -Wl,-Map=.pio/build/TFM_100/firmware.map  ; generate the .map file with symbols and sizes
 
 monitor_speed=115200
+upload_port=COM17

--- a/firmware/src/energy.cpp
+++ b/firmware/src/energy.cpp
@@ -51,6 +51,22 @@ void Energy::increase_energy(float supply_temp, float return_temp, float volume_
     energy_total += dE;
     energy_24h += dE;
 
-    // Persist
-    saveToEEPROM();
+    // Mark as dirty; actual EEPROM write is deferred to persistIfDue()
+    eeprom_dirty = true;
+}
+
+/**
+ * @brief Persist energy to EEPROM if dirty and the minimum interval has elapsed.
+ * @param now_ms Current millis() timestamp
+ */
+void Energy::persistIfDue(uint32_t now_ms)
+{
+    if (!eeprom_dirty)
+        return;
+    if ((now_ms - last_eeprom_save_ms) >= ENERGY_EEPROM_SAVE_INTERVAL_MS)
+    {
+        saveToEEPROM();
+        eeprom_dirty = false;
+        last_eeprom_save_ms = now_ms;
+    }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -363,6 +363,9 @@ void loop()
   return_sensor.process();
   flowObj.process();
 
+  // Persist energy counters to EEPROM at most once per minute (rate-limited to reduce EEPROM wear)
+  energyObj.persistIfDue(millis());
+
   diagComm.process(millis());
 
   // Set node mode depending on flow present

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -150,6 +150,10 @@ void processReceivedCanMessages()
   INT32U canId = 0;
   INT8U ext = 0;
 
+  // Clear the interrupt flag before draining the RX buffer so any interrupt
+  // arriving during processing sets the flag again and is handled next loop.
+  canRxPending = false;
+
   // Process all available CAN messages
   while (CAN0.checkReceive() == CAN_MSGAVAIL)
   {
@@ -181,9 +185,6 @@ void processReceivedCanMessages()
       }
     }
   }
-
-  // Clear the interrupt flag after processing all messages
-  canRxPending = false;
 }
 
 void setup()

--- a/firmware/src/power.cpp
+++ b/firmware/src/power.cpp
@@ -23,7 +23,7 @@ float Power::getPowerPercent()
 }
 
 /**
- * @brief Load persisted energy state from EEPROM into this instance
+ * @brief Load persisted power state from EEPROM into this instance
  * @return true if valid data was loaded (magic matches), false otherwise
  */
 bool Power::loadFromEEPROM()

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -21,10 +21,10 @@
               :temp-mandata-c="tempMandataC"
               :temp-ritorno-c="tempRitornoC"
               :water-flow-lh="waterFlowLh"
-              :powerKW="powerKW"
-              :powerPerc="powerPerc"
-              :energy24hKWh="energy24hKWh"
-              :energyTotalKWh="energyTotalKWh"
+              :power-kW="powerKW"
+              :power-perc="powerPerc"
+              :energy24h-kwh="energy24hKWh"
+              :energyTotal-kwh="energyTotalKWh"
               @reset-energy-24h="onReset24h"
               @reset-energy-total="onResetTotal"
             />
@@ -101,7 +101,7 @@ function onResetTotal() {
 
 function onResetDsm() {
   // Send erase command to device: E\r\n
-  serial.write('E\r\n')
+  serial.write('E')
   // Clear faults from UI
   faults.value = []
 }

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -21,7 +21,7 @@
               :temp-mandata-c="tempMandataC"
               :temp-ritorno-c="tempRitornoC"
               :water-flow-lh="waterFlowLh"
-              :power-kW="powerKW"
+              :power-kw="powerKW"
               :power-perc="powerPerc"
               :energy24h-kwh="energy24hKWh"
               :energy-total-kwh="energyTotalKWh"

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -24,7 +24,7 @@
               :power-kW="powerKW"
               :power-perc="powerPerc"
               :energy24h-kwh="energy24hKWh"
-              :energyTotal-kwh="energyTotalKWh"
+              :energy-total-kwh="energyTotalKWh"
               @reset-energy-24h="onReset24h"
               @reset-energy-total="onResetTotal"
             />

--- a/webui/src/components/TelemetryCard.vue
+++ b/webui/src/components/TelemetryCard.vue
@@ -63,7 +63,7 @@
           <v-list-item :prepend-icon="isMobile ? '' : 'mdi-transmission-tower'">
             <v-list-item-title>Potenza istantanea:</v-list-item-title>
             <template v-slot:append>
-              {{ fmt(powerKW) }} kW
+              {{ fmt(powerKw) }} kW
             </template>
           </v-list-item>
 
@@ -113,7 +113,7 @@ const props = defineProps({
   tempMandataC: { type: Number, required: true },
   tempRitornoC: { type: Number, required: true },
   waterFlowLh: { type: Number, required: true },
-  powerKW: { type: Number, required: true },
+  powerKw: { type: Number, required: true },
   powerPerc: { type: Number, default: 10 },
   energy24hKwh: { type: Number, required: true },
   energyTotalKwh: { type: Number, required: true },

--- a/webui/src/components/TelemetryCard.vue
+++ b/webui/src/components/TelemetryCard.vue
@@ -70,14 +70,14 @@
           <v-list-item :prepend-icon="isMobile ? '' : 'mdi-clock'">
             <v-list-item-title>Energia 24h</v-list-item-title>
             <template v-slot:append>
-              {{ fmt(energy24hKWh) }} kWh
+              {{ fmt(energy24hKwh) }} kWh
             </template>
           </v-list-item>
 
           <v-list-item :prepend-icon="isMobile ? '' : 'mdi-lightning-bolt'">
             <v-list-item-title>Energia totale:</v-list-item-title>
             <template v-slot:append>
-              {{ fmt(energyTotalKWh) }} kWh
+              {{ fmt(energyTotalKwh) }} kWh
             </template>
           </v-list-item>
         </v-col>
@@ -115,8 +115,8 @@ const props = defineProps({
   waterFlowLh: { type: Number, required: true },
   powerKW: { type: Number, required: true },
   powerPerc: { type: Number, default: 10 },
-  energy24hKWh: { type: Number, required: true },
-  energyTotalKWh: { type: Number, required: true },
+  energy24hKwh: { type: Number, required: true },
+  energyTotalKwh: { type: Number, required: true },
 })
 
 // Emits for parent to handle resets

--- a/webui/src/plugins/webserial/index.ts
+++ b/webui/src/plugins/webserial/index.ts
@@ -23,6 +23,6 @@ export function createWebSerialPlugin(options: WebSerialPluginOptions = {}) {
 
 export function useSerial(): { service: WebSerialService; state: UnwrapNestedRefs<SerialState> } {
   const ctx = inject<{ service: WebSerialService; state: UnwrapNestedRefs<SerialState> }>(key);
-  if (!ctx) throw new Error("WebSerialPlugin non installato");
+  if (!ctx) throw new Error("WebSerialPlugin not installed");
   return ctx;
 }

--- a/webui/src/plugins/webserial/service.ts
+++ b/webui/src/plugins/webserial/service.ts
@@ -45,7 +45,7 @@ export class WebSerialService {
   }
 
   async requestPort() {
-    if (!this.serial) throw new Error("Web Serial non disponibile");
+    if (!this.serial) throw new Error("Web Serial not available");
     this.port = await this.serial.requestPort({ filters: this.opts.filters });
     this.state.selectedPort = this.port;
     if (this.state.ports.every(p => p !== this.port)) this.state.ports.push(this.port);
@@ -77,7 +77,7 @@ export class WebSerialService {
   }
 
   async open(baud?: number) {
-    if (!this.port) throw new Error("Nessuna porta selezionata");
+    if (!this.port) throw new Error("No port selected");
     try {
       const info = this.port.getInfo?.();
       console.debug('[WebSerial] open: attempting to open port', { baud: baud ?? this.opts.baudRate, info });
@@ -151,7 +151,7 @@ export class WebSerialService {
   }
 
   async write(data: string | Uint8Array) {
-    if (!this.writer) throw new Error("Porta non aperta");
+    if (!this.writer) throw new Error("Port not open");
     this.writeQueue = this.writeQueue.then(async () => {
       const payload = (typeof data === 'string' && this.opts.textMode && this.opts.lineEnding)
         ? data + this.opts.lineEnding


### PR DESCRIPTION
This pull request introduces several improvements and fixes across both the firmware and web UI codebases. The most significant changes are focused on reducing EEPROM wear by rate-limiting energy persistence, correcting unit labels and naming for power and energy values, improving overflow handling in time calculations, and updating error messages for clarity.

**Firmware: EEPROM persistence and overflow handling**
* Added rate-limited energy persistence: Energy counters are now marked as dirty on update and only saved to EEPROM at most once per minute, reducing EEPROM wear (`Energy::persistIfDue`, `ENERGY_EEPROM_SAVE_INTERVAL_MS`, and integration in main loop) [[1]](diffhunk://#diff-f1699d3524134b511fb825ae079ad6199608a57b80b4fb01562a655834f149b3R53-R54) [[2]](diffhunk://#diff-01541a8dd3173292413a380ebbf72f5d7dfc0f37d91f6f55d8a5a1b5dad20578R96-R103) [[3]](diffhunk://#diff-01541a8dd3173292413a380ebbf72f5d7dfc0f37d91f6f55d8a5a1b5dad20578R134-R135) [[4]](diffhunk://#diff-67b1c668cc963889f3058f0df465d776129fac49252e05f1263ae8f05897375cL54-R71) [[5]](diffhunk://#diff-8b877285b1287e2c225a5db5aef0e2b6a599a550b84885b7532764ad56c84d43R367-R369).
* Improved overflow handling in time calculations for flow measurement and scheduler tick, ensuring correct behavior when timer values wrap around (`flow_ISR`, `Scheduler::run`) [[1]](diffhunk://#diff-4ad868c3134ea047bbc858570374969c4b115c6a18ede33375e13fa08cfff12aL21-R26) [[2]](diffhunk://#diff-b633854cef3d29afdaff440eeac05e8408cdaf11f9ccb069333c79feaf476ee7L20-R26).

**Firmware: Power and Energy units and initialization**
* Corrected unit labels for power (kW) and energy (kWh) in comments and method signatures, and set the default maximum power to 24.0 kW if EEPROM is invalid (`Power` class) [[1]](diffhunk://#diff-9e8989928b611223b78dc6b953b5dd287fe1e28ebd7bde4aed7aae4b40526d00L26-R27) [[2]](diffhunk://#diff-9e8989928b611223b78dc6b953b5dd287fe1e28ebd7bde4aed7aae4b40526d00L51-R65).
* Updated EEPROM magic number for power region to reflect layout changes.

**Web UI: Prop naming and display**
* Standardized prop names for energy and power values to use consistent casing (`energy24hKwh`, `energyTotalKwh`, `power-kW`, etc.) and updated UI components to match [[1]](diffhunk://#diff-f93681dbd578b4ea2de30c5e7f806146315043e292ad1c5a048204aa6f2a51f2L24-R27) [[2]](diffhunk://#diff-9d5c19bd581defa2890ba6cdd2f8d49496f4e127b289f35e16a718f956d9c754L73-R80) [[3]](diffhunk://#diff-9d5c19bd581defa2890ba6cdd2f8d49496f4e127b289f35e16a718f956d9c754L118-R119).

**Web UI: Error message localization**
* Changed error messages in WebSerial plugin and service from Italian to English for clarity and consistency [[1]](diffhunk://#diff-b64aae0ba45c4d114fa7c46bb9cb15482a17d62f074c798ab0575490cb7793d2L26-R26) [[2]](diffhunk://#diff-dbbae0f27bbf84e7a19e941fe736403c98fa657b6d82749b3ce277366925f846L48-R48) [[3]](diffhunk://#diff-dbbae0f27bbf84e7a19e941fe736403c98fa657b6d82749b3ce277366925f846L80-R80) [[4]](diffhunk://#diff-dbbae0f27bbf84e7a19e941fe736403c98fa657b6d82749b3ce277366925f846L154-R154).

**Build and configuration**
* Added support for override configuration files in PlatformIO and updated build flags comments for clarity; also added `platformio_override.ini` to `.gitignore` [[1]](diffhunk://#diff-f0ee0d0e7ec3cc340de0b44bb66ecab00ce9db7fa5830a5cdc3273fa5b429b61R13) [[2]](diffhunk://#diff-f0ee0d0e7ec3cc340de0b44bb66ecab00ce9db7fa5830a5cdc3273fa5b429b61L28-R44) [[3]](diffhunk://#diff-6f67de6dd67459a2a8f2cb0e56e209e70b00c1c9f764fe842bb54a854fb544adR6).

Let me know if you'd like more details on any specific change!